### PR TITLE
refactor: cleanup, storyboard grid default, director routing

### DIFF
--- a/video-maker/skills/director/SKILL.md
+++ b/video-maker/skills/director/SKILL.md
@@ -2,11 +2,13 @@
 name: director
 description: >
   AI video creative director for any video type — product, drama, comedy,
-  brand film, animated comic. Analyzes materials, suggests 2-3 style
+  brand film, animated comic, action sequence. Analyzes materials, suggests 2-3 style
   directions, generates video prompts, and submits video tasks. Use when
   user says "make a video", "video idea", "creative direction", "help me
-  shoot", "I want a video", "做视频", "帮我拍", "视频创意". Do NOT use for
-  downloading videos or editing existing footage.
+  shoot", "I want a video", "video script", "storyboard", "generate video",
+  "action sequence", "做视频", "帮我拍", "视频创意", "短视频脚本", "分镜",
+  "生成视频". Do NOT use for downloading videos or editing existing footage.
+  This skill is the ONLY entry point for video creation in the Visiono project.
 allowed-tools: Bash, Read
 metadata:
   author: renoise

--- a/video-maker/skills/renoise-gen/SKILL.md
+++ b/video-maker/skills/renoise-gen/SKILL.md
@@ -77,10 +77,10 @@ node ${CLAUDE_SKILL_DIR}/renoise-cli.mjs task create --prompt "Wrist-level shot 
 | Duration range | 5-15s, any integer |
 | **Default duration** | **15s** (maximize storyboard capability) |
 | Aspect ratio | `1:1`, `16:9`, `9:16` |
-| Recommended mode | **Text-to-Video** (text-only prompt, most stable) |
+| Recommended mode | **Image-to-Video with storyboard grid** (best visual consistency) |
 | Prompt language | **English**, natural narrative paragraphs |
 
-> **Default to Text-to-Video**: Image/Video references containing human faces are often blocked by privacy detection (`PrivacyInformation` error). Text-only is not subject to this limitation and has the highest success rate.
+> **Default to Image-to-Video with storyboard grid**: Generate reference images as a 9-grid or 16-grid composite, upload as `ref_image`. Grid images bypass privacy detection more reliably than individual face photos because faces are small within the grid cells. **Fallback to Text-to-Video** only when the grid is still blocked by privacy detection (`PrivacyInformation` error) — text-only prompts are never subject to this limitation.
 
 ### nano-banana-2 (Image)
 
@@ -222,6 +222,7 @@ credit me → task generate --model nano-banana-2 --prompt "..." --resolution 2k
 ```
 material upload → task generate (--materials "ID:role")
 ```
+**Preferred**: Use storyboard grid images as ref_image — see "Storyboard Grid Workflow" section below.
 
 ### With Character Reference
 ```
@@ -239,6 +240,51 @@ node ${CLAUDE_SKILL_DIR}/renoise-cli.mjs task create --prompt "[0-5s] ... [5-12s
 ```
 
 **Maintain consistency**: Repeat full character appearance description at the start of each segment's prompt, use consistent lighting/style keywords, bridge with `Continuing from the previous shot:`.
+
+## Storyboard Grid Workflow (Preferred Approach)
+
+The storyboard grid method produces the best visual consistency across clips by anchoring each generation to a reference image from a unified grid.
+
+### Why Storyboard Grid?
+
+| Approach | Visual Consistency | Privacy Detection Risk | Setup Effort |
+|----------|-------------------|----------------------|--------------|
+| **Storyboard Grid (preferred)** | Highest — all panels share style context | Low — faces are small in grid cells | Medium |
+| Text-to-Video (fallback) | Lower — model interprets style differently each call | None | Low |
+| Individual ref_image | Medium | High — close-up faces trigger blocking | Medium |
+
+### Step-by-Step
+
+1. **Generate reference images as a grid**: Use Midjourney (v7) or Gemini to create a single composite image containing all shots as panels in a 3x3 (9-grid) or 4x4 (16-grid) layout. Each panel shows one key moment from a shot with consistent character appearance and style.
+
+2. **Upload the grid as material**:
+   ```bash
+   node ${CLAUDE_SKILL_DIR}/renoise-cli.mjs material upload storyboard_grid.png
+   # Returns material ID
+   ```
+
+3. **Generate video with ref_image + time-annotated prompt**:
+   ```bash
+   node ${CLAUDE_SKILL_DIR}/renoise-cli.mjs task generate \
+     --prompt "Follow the attached storyboard panels. [0-5s] ... [5-10s] ... [10-15s] ..." \
+     --materials "MATERIAL_ID:ref_image" \
+     --duration 15 --ratio 16:9
+   ```
+
+4. **For videos > 15s**: Split into multiple grids (e.g., 3x3 for shots 1-9, another for shots 10-18), generate each 15s segment with its corresponding grid.
+
+5. **Fallback**: If a grid triggers `PrivacyInformation`, retry without `--materials` (pure text-to-video), copying full character descriptions into the prompt.
+
+### When to Use Each Approach
+
+| Signal | Approach |
+|--------|----------|
+| Any project with recurring characters | **Storyboard grid** (preferred) |
+| Product shots, landscapes, no people | Image-to-Video with individual ref_image |
+| Grid ref_image blocked by privacy detection | **Text-to-Video** (fallback) |
+| Quick one-off generation, no consistency needs | Text-to-Video |
+
+---
 
 ## Prompt Writing
 

--- a/video-maker/skills/renoise-gen/references/video-capabilities.md
+++ b/video-maker/skills/renoise-gen/references/video-capabilities.md
@@ -330,6 +330,8 @@ Good: `Wide shot, camera tracks alongside at ground level, accelerating as the h
 | | Macro push | extreme macro push | Material detail |
 | | Static | locked-off static | Freeze/ending |
 | **Angle** | Low angle | low angle | Authority/impact |
+| | Worm's eye | worm's eye view, ultra-low angle | Monumental scale, hero entrance |
+| | Dutch angle | Dutch angle, tilted horizon | Tension, unease, psychological instability |
 | | Overhead | overhead / bird's eye | Overview/spatial |
 | | Fisheye | fisheye lens | Fun/exaggerated |
 | | POV | first-person POV | Immersive experience |
@@ -339,7 +341,51 @@ Good: `Wide shot, camera tracks alongside at ground level, accelerating as the h
 | **Focus** | Shallow DOF | shallow depth of field | Subject isolation |
 | | Focus pull | rack focus | Guide viewer's eye |
 | **Special** | Vertigo | dolly zoom / vertigo effect | Psychological impact |
+| | Crane up | crane shot rising | Reveal, epic scale, emotional lift |
 | | Wipe transition | wipe transition through obstruction | Seamless scene change |
+
+### Dramatic Camera Angles — Avoiding Flat Footage
+
+Default eye-level, medium-distance shots produce flat, boring footage. Deliberately choose dramatic angles to inject energy:
+
+**Low Angle / Worm's Eye View**: Camera at ground level looking up. Makes subjects feel powerful, monumental. Use for hero entrances, authority, product reveals from below.
+```
+Camera at ground level looking up at the swordsman, worm's eye view. He towers against the stormy sky, cape billowing overhead.
+```
+
+**Dutch Angle (Tilted Horizon)**: 15-degree tilt creates unease. Use for tension, villain reveals, psychological instability, chase sequences.
+```
+Dutch angle, 15-degree tilt. The corridor stretches ahead, walls leaning ominously. Subject walks toward camera, slightly off-center.
+```
+
+**Extreme Macro**: Fill the entire frame with texture detail. Use for product material, food close-ups, mechanical detail, nature textures.
+```
+Extreme macro on the watch dial, filling frame with brushed titanium texture. Slow push-in reveals the engraved serial number.
+```
+
+**Vertigo / Dolly Zoom**: Camera pulls back while lens zooms in (or vice versa). Subject stays same size but background warps. Use for revelation moments, emotional shock, character realization.
+```
+Dolly zoom — camera pulls back while lens zooms in. The subject stays the same size but the background warps and stretches. Psychological disorientation.
+```
+
+**Whip Pan Transitions**: Fast horizontal pan with motion blur connecting two scenes. Use for energy bursts, music video beat transitions, location changes.
+```
+Whip pan right with heavy motion blur — hard cut to the next scene already in motion. No pause between scenes.
+```
+
+### Shot Density Guide
+
+Higher shot density = more dynamic, engaging footage. Match density to content energy:
+
+| Content Type | Shots per 15s | Avg Shot Length | Camera Variety |
+|-------------|--------------|-----------------|----------------|
+| Action / martial arts | **5-7** | 2-3s | Every shot: different size + angle |
+| Music video / montage | **5-7** | 2-3s | Alternate: close-up ↔ wide, static ↔ motion |
+| Drama / dialogue | 4-5 | 3-4s | Shot-reverse-shot + establishing |
+| Product / showcase | 3-5 | 3-5s | Orbit + macro + wide reveal |
+| Atmospheric / art | 2-3 | 5-7s | Slow movements, held frames |
+
+**Rule of thumb**: If your 15s prompt has fewer than 3 distinct camera setups with time annotations, it is probably too flat. Add at least one dramatic angle change.
 
 ### Example: 15s Multi-Storyboard Prompt
 

--- a/video-maker/skills/short-film-editor/SKILL.md
+++ b/video-maker/skills/short-film-editor/SKILL.md
@@ -475,5 +475,5 @@ Read ${CLAUDE_SKILL_DIR}/examples/mystery-package-4shot.md
 **Solution**: Switch to text-to-video. Describe people in the prompt using the Character Bible.
 
 ### Insufficient credits (402)
-**Cause**: YOUMENG balance too low for all shots.
+**Cause**: Renoise balance too low for all shots.
 **Solution**: Run `renoise-cli.mjs me` to check balance, estimate total cost, and inform user before starting batch generation.

--- a/video-maker/skills/short-film-editor/scripts/batch-generate.sh
+++ b/video-maker/skills/short-film-editor/scripts/batch-generate.sh
@@ -42,7 +42,7 @@ if [[ ! -f "$PROMPTS_FILE" ]]; then
   exit 1
 fi
 
-# ---- Locate youmeng-cli ----
+# ---- Locate renoise-cli ----
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CLI="${SCRIPT_DIR}/../../renoise-gen/renoise-cli.mjs"
 

--- a/video-maker/skills/video-download/SKILL.md
+++ b/video-maker/skills/video-download/SKILL.md
@@ -1,16 +1,16 @@
 ---
 name: video-download
 description: >
-  Downloads videos from YouTube, TikTok, and other platforms using yt-dlp.
-  Use when user says "download video", "save video", "yt-dlp", or pastes a
-  video URL (youtube.com, tiktok.com, etc). Do NOT use for AI video generation
-  or video editing.
+  Downloads videos from YouTube, TikTok, Douyin, Bilibili, Instagram, XiaoHongShu and 1000+ platforms.
+  Primary: yt-dlp. Fallback: agent-browser + GreenVideo for Douyin/TikTok when yt-dlp fails.
+  Use when user says "download video", "save video", "下载视频", "抓取视频", "无水印下载",
+  or pastes a video URL. Do NOT use for AI video generation or video editing.
 allowed-tools: Bash
 metadata:
   author: renoise
-  version: 0.1.0
+  version: 0.2.0
   category: utility
-  tags: [download, youtube, tiktok, yt-dlp]
+  tags: [download, youtube, tiktok, douyin, yt-dlp, greenvideo]
 ---
 
 # Video Download
@@ -26,6 +26,11 @@ yt-dlp --version
 ```
 
 If missing: `brew install yt-dlp` (macOS) or `pip install yt-dlp`.
+
+### Optional (for Douyin/TikTok fallback)
+
+- `agent-browser` installed globally (`npm install -g agent-browser`)
+- Chrome for Testing installed (`agent-browser install`)
 
 ## Usage
 
@@ -74,7 +79,7 @@ The script prints one of three status lines:
 
 | Error | Solution |
 |-------|----------|
-| `HTTP Error 403` (TikTok) | Script auto-retries with cookies. If still failing, ensure Chrome has active TikTok session |
+| `HTTP Error 403` (TikTok/Douyin) | Script auto-retries with cookies. If still failing, use **GreenVideo Fallback** below |
 | `--max-filesize` skipped | Video exceeds 200M limit. Download manually with `-f 'best[height<=720]'` |
 | `is not a valid URL` | Ensure URL is wrapped in single quotes |
 | `Requested formats are incompatible` | yt-dlp auto-transcodes, no action needed |
@@ -86,3 +91,71 @@ The script prints one of three status lines:
 | YouTube | `watch?v=`, `shorts/`, `embed/`, `youtu.be/` → 11-char ID | `yt-dQw4w9WgXcQ` |
 | TikTok | 15+ digit numeric ID in URL | `tk-7571284267028729101` |
 | Other | Base64url of URL, first 16 chars | `vid-aHR0cHM6Ly93d3` |
+
+---
+
+## GreenVideo Fallback (for Douyin/TikTok)
+
+When yt-dlp fails for Douyin or TikTok URLs (common with 403 errors or region-restricted content), use GreenVideo as a browser-based fallback. Requires `agent-browser` (see Prerequisites).
+
+### Decision Logic
+
+```
+User gives URL → Try yt-dlp first
+                   ↓ fails (403 / no result)
+               Is it Douyin/TikTok?
+                   ↓ yes
+               Use agent-browser + GreenVideo
+                   ↓ no
+               Report error, suggest manual download
+```
+
+### Step 1: Open GreenVideo
+
+```bash
+agent-browser open "https://greenvideo.cc/en/"
+```
+
+### Step 2: Paste URL and Parse
+
+```bash
+agent-browser snapshot
+# Find the input textbox ref (e.g., @e63)
+agent-browser fill <input-ref> "<video-url>"
+agent-browser click <start-button-ref>
+```
+
+Wait 5 seconds for parsing to complete, then snapshot to verify results.
+
+### Step 3: Extract Video Direct URL
+
+The video URL is stored in Nuxt state. Extract it with:
+
+```bash
+agent-browser eval "
+(function() {
+  const nuxtData = window.__NUXT__;
+  if (!nuxtData) return 'ERROR: No Nuxt data found';
+  const str = JSON.stringify(nuxtData);
+  const mp4Match = str.match(/https?:[^\\\"]*(?:mp4|video|play|aweme|douyinvod|bilivideo)[^\\\"]{0,500}/g);
+  if (mp4Match && mp4Match.length > 0) return mp4Match[0];
+  return 'ERROR: No video URL found in Nuxt state';
+})()
+"
+```
+
+### Step 4: Download and Cleanup
+
+```bash
+curl -L -o ~/Downloads/<filename>.mp4 "<extracted-video-url>"
+agent-browser close
+```
+
+### GreenVideo Troubleshooting
+
+| Issue | Solution |
+|-------|----------|
+| Parse fails or no result | Check URL is valid and publicly accessible. Some `/user/self` URLs need the direct video URL |
+| No video URL in Nuxt state | Try clicking download button and check for `<video>` elements: `agent-browser eval "document.querySelectorAll('video').length"` |
+| Download fails (403) | Video URLs expire quickly — extract and download immediately. Try adding `-H "Referer: https://greenvideo.cc/"` to curl |
+| agent-browser not responding | Run `agent-browser close` then `agent-browser open "https://greenvideo.cc/en/"` |

--- a/video-maker/skills/youmeng-gen/.env
+++ b/video-maker/skills/youmeng-gen/.env
@@ -1,2 +1,0 @@
-YOUMENG_TOKEN=birOmpFz4xHeVAMmkKvbIecDDupBsM3N.1MnjHTPvWb2BNNKmF7bbEeBzaGVrygAkLEb69P6cL%2B0%3D
-YOUMENG_BASE_URL=https://staging--ujgsvru36x4korjj10nq.edgespark.app


### PR DESCRIPTION
## Summary
- Remove legacy `youmeng-gen` skill
- Flip default to storyboard grid workflow for best visual consistency
- Add dramatic camera movement guide to video-capabilities
- Merge GreenVideo fallback into video-download skill (yt-dlp + agent-browser)
- Expand director trigger keywords to prevent routing conflicts with standalone skills

## Changes
- `director/SKILL.md` — Added trigger keywords: "video script", "storyboard", "generate video", "action sequence", "分镜", "短视频脚本", "生成视频"
- `renoise-gen/SKILL.md` — Storyboard grid workflow, multi-segment docs
- `renoise-gen/references/video-capabilities.md` — Camera writing guide additions
- `video-download/SKILL.md` — GreenVideo agent-browser fallback section
- `short-film-editor/` — Minor fixes
- Removed `youmeng-gen/` (legacy)

## Test plan
- [ ] Verify director skill triggers on "video script" and "storyboard" requests
- [ ] Verify video-download handles Douyin URLs with GreenVideo fallback
- [ ] Verify storyboard grid workflow in renoise-gen docs is accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)