### PR TITLE
fix: rename plugin from Video Maker to Renoise

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
-  "name": "video-maker",
+  "name": "renoise",
   "description": "AI video production skills — creative direction, generation, editing, and e-commerce content",
   "version": "0.2.0",
   "author": {

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
-  "id": "video-maker",
-  "name": "Video Maker",
+  "id": "renoise",
+  "name": "Renoise",
   "description": "AI video production skills — creative direction, generation, editing, and e-commerce content",
   "version": "0.2.0",
   "configSchema": {


### PR DESCRIPTION
## Summary
- Rename plugin id from `video-maker` to `renoise`
- Rename display name from "Video Maker" to "Renoise"