### PR TITLE
fix: rename plugin from video-maker to renoise

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   "description": "Official Claude Code plugins by Renoise",
   "plugins": [
     {
-      "name": "video-maker",
+      "name": "renoise",
       "version": "0.2.0",
       "source": "./",
       "description": "AI video production skills — creative direction, generation, editing, and e-commerce content"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
-  "name": "video-maker",
+  "name": "renoise",
   "description": "AI video production skills — creative direction, generation, editing, and e-commerce content",
   "version": "0.2.0",
   "author": {

--- a/README.md
+++ b/README.md
@@ -29,19 +29,19 @@ claude plugin marketplace add ArcoCodes/renoise-plugins-official
 2. Install the plugin:
 
 ```bash
-claude plugin install video-maker@renoise-plugins-official
+claude plugin install renoise@renoise-plugins-official
 ```
 
 ### OpenClaw
 
 ```bash
-openclaw plugins install @renoise/video-maker
+openclaw plugins install @renoise/renoise
 ```
 
 3. Launch Claude Code and run the setup command to connect your Renoise account:
 
 ```
-/video-maker:setup
+/renoise:setup
 ```
 
 This will guide you through connecting your API key and enabling the real-time credit balance display in the status bar.

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ claude plugin install renoise@renoise-plugins-official
 ### OpenClaw
 
 ```bash
-openclaw plugins install @renoise/renoise
+openclaw plugins install @renoise/plugin
 ```
 
 3. Launch Claude Code and run the setup command to connect your Renoise account:

--- a/commands/setup.md
+++ b/commands/setup.md
@@ -3,7 +3,7 @@ description: Configure Renoise Credits statusLine display
 allowed-tools: Bash, Read, Edit, Write, AskUserQuestion
 ---
 
-# Video Maker StatusLine Setup
+# Renoise StatusLine Setup
 
 Set up the Renoise Credits display in Claude Code's status bar. Merges with claude-hud if installed.
 
@@ -15,7 +15,7 @@ Find a JavaScript runtime (prefer bun for performance):
 command -v bun 2>/dev/null || command -v node 2>/dev/null
 ```
 
-If empty, tell the user to install bun (https://bun.sh) or Node.js (https://nodejs.org), then re-run `/video-maker:setup`.
+If empty, tell the user to install bun (https://bun.sh) or Node.js (https://nodejs.org), then re-run `/renoise:setup`.
 
 Save the runtime absolute path as `{RUNTIME_PATH}`.
 
@@ -23,7 +23,7 @@ Save the runtime absolute path as `{RUNTIME_PATH}`.
 
 ```bash
 CLAUDE_DIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
-ls -d "$CLAUDE_DIR"/plugins/cache/renoise-plugins-official/video-maker/*/ 2>/dev/null | awk -F/ '{ print $(NF-1) "\t" $(0) }' | sort -t. -k1,1n -k2,2n -k3,3n -k4,4n | tail -1 | cut -f2-
+ls -d "$CLAUDE_DIR"/plugins/cache/renoise-plugins-official/renoise/*/ 2>/dev/null | awk -F/ '{ print $(NF-1) "\t" $(0) }' | sort -t. -k1,1n -k2,2n -k3,3n -k4,4n | tail -1 | cut -f2-
 ```
 
 Save as `{PLUGIN_DIR}`. If empty, the plugin may not be installed via marketplace. Ask user to verify installation.
@@ -34,12 +34,12 @@ Generate the statusLine command:
 
 **If runtime is bun:**
 ```
-bash -c 'plugin_dir=$(ls -d "${CLAUDE_CONFIG_DIR:-$HOME/.claude}"/plugins/cache/renoise-plugins-official/video-maker/*/ 2>/dev/null | awk -F/ '"'"'{ print $(NF-1) "\t" $(0) }'"'"' | sort -t. -k1,1n -k2,2n -k3,3n -k4,4n | tail -1 | cut -f2-); exec "{RUNTIME_PATH}" --env-file /dev/null "${plugin_dir}src/index.ts"'
+bash -c 'plugin_dir=$(ls -d "${CLAUDE_CONFIG_DIR:-$HOME/.claude}"/plugins/cache/renoise-plugins-official/renoise/*/ 2>/dev/null | awk -F/ '"'"'{ print $(NF-1) "\t" $(0) }'"'"' | sort -t. -k1,1n -k2,2n -k3,3n -k4,4n | tail -1 | cut -f2-); exec "{RUNTIME_PATH}" --env-file /dev/null "${plugin_dir}src/index.ts"'
 ```
 
 **If runtime is node:**
 ```
-bash -c 'plugin_dir=$(ls -d "${CLAUDE_CONFIG_DIR:-$HOME/.claude}"/plugins/cache/renoise-plugins-official/video-maker/*/ 2>/dev/null | awk -F/ '"'"'{ print $(NF-1) "\t" $(0) }'"'"' | sort -t. -k1,1n -k2,2n -k3,3n -k4,4n | tail -1 | cut -f2-); exec npx tsx "${plugin_dir}src/index.ts"'
+bash -c 'plugin_dir=$(ls -d "${CLAUDE_CONFIG_DIR:-$HOME/.claude}"/plugins/cache/renoise-plugins-official/renoise/*/ 2>/dev/null | awk -F/ '"'"'{ print $(NF-1) "\t" $(0) }'"'"' | sort -t. -k1,1n -k2,2n -k3,3n -k4,4n | tail -1 | cut -f2-); exec npx tsx "${plugin_dir}src/index.ts"'
 ```
 
 Test the command:
@@ -89,7 +89,7 @@ If not set, guide the user through login:
 
 Read `${CLAUDE_CONFIG_DIR:-$HOME/.claude}/settings.json`.
 
-**If a `statusLine` already exists** and its command does NOT contain "video-maker":
+**If a `statusLine` already exists** and its command does NOT contain "renoise":
 1. Save the existing statusLine command to `~/.renoise/previous-statusline.json`:
    ```json
    { "command": "<existing statusLine command>" }
@@ -115,4 +115,4 @@ After writing, tell the user:
 > **Restart Claude Code** to activate. After restart you'll see:
 > - Your real-time credit balance in the status bar
 > - Low balance warnings when credits are running out
-> - Type `/video-maker:add-credits` anytime to top up
+> - Type `/renoise:add-credits` anytime to top up

--- a/hooks/session-start.sh
+++ b/hooks/session-start.sh
@@ -19,7 +19,7 @@ fi
 
 # Check if statusLine is pointing to our script
 SETTINGS_FILE="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/settings.json"
-if [ -f "$SETTINGS_FILE" ] && grep -q "renoise" "$SETTINGS_FILE" 2>/dev/null && grep -q "statusLine" "$SETTINGS_FILE" 2>/dev/null; then
+if [ -f "$SETTINGS_FILE" ] && grep -q "statusLine" "$SETTINGS_FILE" 2>/dev/null && grep -q "renoise-plugins-official/renoise" "$SETTINGS_FILE" 2>/dev/null; then
   HAS_STATUSLINE=true
 fi
 

--- a/hooks/session-start.sh
+++ b/hooks/session-start.sh
@@ -19,20 +19,20 @@ fi
 
 # Check if statusLine is pointing to our script
 SETTINGS_FILE="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/settings.json"
-if [ -f "$SETTINGS_FILE" ] && grep -q "video-maker" "$SETTINGS_FILE" 2>/dev/null && grep -q "statusLine" "$SETTINGS_FILE" 2>/dev/null; then
+if [ -f "$SETTINGS_FILE" ] && grep -q "renoise" "$SETTINGS_FILE" 2>/dev/null && grep -q "statusLine" "$SETTINGS_FILE" 2>/dev/null; then
   HAS_STATUSLINE=true
 fi
 
 # Case 1: New user — no API key
 if [ "$HAS_KEY" = false ]; then
   # stdout goes to Claude as context — Claude will relay the message to the user
-  echo '[Renoise Video Maker] Plugin installed successfully, but Renoise account is not connected yet. Tell the user: type /video-maker:setup to connect your account. One sentence only.'
+  echo '[Renoise] Plugin installed successfully, but Renoise account is not connected yet. Tell the user: type /renoise:setup to connect your account. One sentence only.'
   exit 0
 fi
 
 # Case 2: Existing user updated plugin — has key but no statusLine
 if [ "$HAS_STATUSLINE" = false ]; then
-  echo '[Renoise Video Maker] Plugin updated — new feature: real-time credit balance in status bar. Tell the user: type /video-maker:setup to activate. One sentence only.'
+  echo '[Renoise] Plugin updated — new feature: real-time credit balance in status bar. Tell the user: type /renoise:setup to activate. One sentence only.'
   exit 0
 fi
 

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
-  "id": "video-maker",
-  "name": "Video Maker",
+  "id": "renoise",
+  "name": "Renoise",
   "description": "AI video production skills — creative direction, generation, editing, and e-commerce content",
   "version": "0.2.0",
   "configSchema": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@renoise/renoise",
+  "name": "@renoise/plugin",
   "version": "0.2.1",
   "license": "Apache-2.0",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@renoise/video-maker",
+  "name": "@renoise/renoise",
   "version": "0.2.1",
   "license": "Apache-2.0",
   "type": "module",

--- a/skills/director/SKILL.md
+++ b/skills/director/SKILL.md
@@ -39,7 +39,7 @@ You are a creative director for AI video production. You guide users from raw id
 
 2. **Load preferences** (if file exists):
    ```
-   Read ~/.claude/video-maker/preferences.json
+   Read ~/.claude/renoise/preferences.json
    ```
 
 3. **Discover available skills** by scanning frontmatter:
@@ -65,7 +65,7 @@ You are a creative director for AI video production. You guide users from raw id
    ```
    If preferences exist, also load the relevant category section:
    ```
-   Read ~/.claude/video-maker/style-profile.md
+   Read ~/.claude/renoise/style-profile.md
    ```
 
 2. **Propose 2-3 style directions** adapted to the specific project. For each:
@@ -201,22 +201,22 @@ Read that skill's SKILL.md and follow its workflow from the appropriate phase (s
 
 2. **Update preference system** after video is delivered:
 
-   **Layer 1 — Core preferences** (`~/.claude/video-maker/preferences.json`):
+   **Layer 1 — Core preferences** (`~/.claude/renoise/preferences.json`):
    Update preferred_styles (frequency-sorted), ratio, dialogue_tone, avoid list, session count.
    Write the entire JSON file (overwrite, not append).
 
-   **Layer 2 — Style profile** (`~/.claude/video-maker/style-profile.md`):
+   **Layer 2 — Style profile** (`~/.claude/renoise/style-profile.md`):
    If the user expressed a new preference or custom style blend, update the relevant category section.
    Only write extracted insights, not raw conversation.
 
-   **Layer 3 — History** (`~/.claude/video-maker/history/YYYY-MM.md`):
+   **Layer 3 — History** (`~/.claude/renoise/history/YYYY-MM.md`):
    Append a brief entry (5 lines max): date, project name, category, style chosen, result.
 
    **Initialize preference files** if they don't exist:
    ```bash
-   mkdir -p ~/.claude/video-maker/history
-   [ -f ~/.claude/video-maker/preferences.json ] || echo '{}' > ~/.claude/video-maker/preferences.json
-   [ -f ~/.claude/video-maker/style-profile.md ] || echo '# Style Profile' > ~/.claude/video-maker/style-profile.md
+   mkdir -p ~/.claude/renoise/history
+   [ -f ~/.claude/renoise/preferences.json ] || echo '{}' > ~/.claude/renoise/preferences.json
+   [ -f ~/.claude/renoise/style-profile.md ] || echo '# Style Profile' > ~/.claude/renoise/style-profile.md
    ```
 
 ## Examples

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * StatusLine entry point for video-maker plugin.
+ * StatusLine entry point for renoise plugin.
  * If user had a previous statusLine command (e.g. claude-hud), runs it and
  * merges its output with the credits display.
  *

--- a/src/render/credits-line.ts
+++ b/src/render/credits-line.ts
@@ -30,9 +30,9 @@ function formatCredits(n: number): string {
 // ── Main Renderer ───────────────────────────────────────────────────────
 
 export interface RenderOptions {
-  /** Slash command name for add-credits. Default: /video-maker:add-credits */
+  /** Slash command name for add-credits. Default: /renoise:add-credits */
   addCreditsCmd?: string
-  /** Slash command name for setup. Default: /video-maker:setup */
+  /** Slash command name for setup. Default: /renoise:setup */
   setupCmd?: string
 }
 
@@ -44,12 +44,12 @@ export function renderCreditsLine(
   data: CreditsData | null,
   opts: RenderOptions = {},
 ): string {
-  const addCreditsCmd = opts.addCreditsCmd ?? '/video-maker:add-credits'
-  const setupCmd = opts.setupCmd ?? '/video-maker:setup'
+  const addCreditsCmd = opts.addCreditsCmd ?? '/renoise:add-credits'
+  const setupCmd = opts.setupCmd ?? '/renoise:setup'
 
   // No cache / not logged in
   if (!data) {
-    return colorize(`🎬 Renoise Video Maker — type ${setupCmd} to complete setup`, GRAY)
+    return colorize(`🎬 Renoise — type ${setupCmd} to complete setup`, GRAY)
   }
 
   const { credits } = data


### PR DESCRIPTION
## Summary
- Rename plugin identifier from `video-maker` to `renoise` across all config files
- Update slash commands: `/video-maker:setup` → `/renoise:setup`, `/video-maker:add-credits` → `/renoise:add-credits`
- Update preference paths: `~/.claude/video-maker/` → `~/.claude/renoise/`
- Update npm package name, session-start hook, and README

Zero `video-maker` or `Video Maker` references remain.

## Test plan
- [ ] Install plugin and verify display name shows "Renoise"
- [ ] Run `/renoise:setup` and confirm it works
- [ ] Verify credit balance shows in status bar after setup