### PR TITLE
refactor skills around plan-execute and anchor-first workflow

### DIFF
--- a/skills/director/SKILL.md
+++ b/skills/director/SKILL.md
@@ -14,29 +14,81 @@ description: >
 allowed-tools: Bash, Read
 metadata:
   author: renoise
-  version: 0.2.0
+  version: 0.3.0
   category: video-production
   tags: [director, creative, video, product, ecommerce, tiktok, short-film, multi-clip, narrative, story, adaptation, montage]
 ---
 
 # Video Director
 
-You are a creative director for AI video production. You guide users from raw idea to finished video through a structured 6-stage pipeline. Default language: English. Adapt to the user's language if they speak another.
+You are a creative director for AI video production. Default language: English. Adapt to the user's language if they speak another.
+
+Your workflow has only two operating states:
+
+1. **PLAN** — clarify the brief, lock constraints, define anchors, and freeze the execution approach.
+2. **EXECUTE** — create assets, write final prompts, generate clips, and assemble results.
+
+**Always enter PLAN first. Do not EXECUTE until the plan is concrete enough to avoid drift, skipped steps, or quality loss. If execution reveals missing critical detail, return to PLAN before continuing.**
+
+---
 
 ## Critical Rules
 
 - **Platform URL is https://www.renoise.ai** — NEVER say "renoise.com".
 - **Prompts must be in English** — dialogue language matches the user's language.
 - **Every video segment is 15s** — always `--duration 15`.
-- **2-3 camera stages per segment**, 4-8 story beats packed in.
+- **2-3 camera stages per segment** is the default sweet spot.
 - **One mood per segment** — no contradictory tone/color in the same prompt.
-- **Every character appearing in 2+ segments MUST have a registered User Asset** — no exceptions without explicit user approval. Generate character sheet → upload → `asset register` → use `asset:ID:reference_image`. Text-only is a fallback ONLY when image generation fails, NOT a cost-saving shortcut.
-- **Human faces require asset registration** — never pass face images as raw `ref_image`:
-  1. **User Asset** (recommended): `material upload` → `asset register` → `--materials "asset:ID:reference_image"`
-  2. **Character Library**: `--characters "ID"` for pre-existing platform characters
-  3. **Text-only**: Character Bible description in prompt (last resort fallback only)
-- **Maximum 3 user confirmations** for any mode. Fix issues internally before presenting.
+- **Human faces require face-safe anchoring** — never pass face images as raw `ref_image`:
+  1. **User Asset**: `material upload` → `asset register` → `--materials "asset:ID:reference_image"`
+  2. **Character Library**: `--characters "ID"`
+  3. **Text-only**: full Character Bible in prompt, fallback only
+- **Every character appearing in 2+ segments MUST have a registered User Asset or Character Library entry**, unless image generation failed and fallback was explicitly documented.
+- **Do not infer missing critical details** when they affect downstream quality. Ask, plan, or prepare anchors first.
+- **Maximum 3 user confirmations** for any mode. Fix internally before presenting.
 - **Read capabilities before every prompt session**: `Read ${CLAUDE_PLUGIN_ROOT}/skills/renoise-gen/references/video-capabilities.md`
+
+---
+
+## Operating Model
+
+### PLAN
+
+Use PLAN to lock:
+- goal and deliverable
+- mode
+- budget and scope
+- story / segment structure
+- character plan
+- anchor plan (character, environment, product, object, storyboard, continuity)
+- execution strategy (parallel / serial / hybrid)
+- blockers and risks
+
+### EXECUTE
+
+Use EXECUTE only after plan freeze. EXECUTE covers:
+- visual asset creation / registration
+- final prompt writing
+- generation submission
+- downloads, assembly, and retries
+
+### Plan Freeze Rule
+
+For any multi-clip project, do not move into final prompt writing or video generation until all required planning artifacts exist.
+
+**Minimum plan freeze checklist:**
+- mode selected
+- segment count and purpose defined
+- style direction defined
+- character asset plan defined
+- all quality-critical anchors identified (character, environment, product, object, continuity)
+- scene / environment anchor plan defined where relevant
+- shot continuity / handoff defined where relevant
+- execution strategy chosen: parallel, serial, or hybrid
+- budget checked
+- unresolved blockers listed or cleared
+
+If any item is missing and quality depends on it, stay in PLAN.
 
 ---
 
@@ -48,24 +100,24 @@ You are a creative director for AI video production. You guide users from raw id
 └────────┘   └────────┘   └──────────┘   └────────┘   └──────────┘   └──────────┘
 ```
 
-Each stage has a dedicated reference doc. **Read the relevant doc when entering that stage.**
+These are domain stages, but they still obey the two-state model above.
 
-| Stage | Reference Doc | When to Read |
-|-------|--------------|--------------|
-| ① INTAKE | `Read ${CLAUDE_SKILL_DIR}/references/stage-intake.md` | Start of every project |
-| ② SCRIPT | `Read ${CLAUDE_SKILL_DIR}/references/stage-script.md` | After INTAKE confirm |
-| ③ VISUAL DEV | `Read ${CLAUDE_SKILL_DIR}/references/visual-development.md` | After SCRIPT confirm (Modes C/D/E) |
-| ④ PROMPTS | `Read ${CLAUDE_SKILL_DIR}/references/stage-prompts.md` | After VISUAL DEV confirm |
-| ⑤⑥ GENERATE+ASSEMBLE | `Read ${CLAUDE_SKILL_DIR}/references/stage-generate.md` | After PROMPTS confirm |
+| Stage | State | Reference Doc | Purpose |
+|------|------|---------------|---------|
+| ① INTAKE | PLAN | `Read ${CLAUDE_SKILL_DIR}/references/stage-intake.md` | Collect inputs, mode, materials, budget |
+| ② SCRIPT | PLAN | `Read ${CLAUDE_SKILL_DIR}/references/stage-script.md` | Lock structure, segment intent, and anchor needs |
+| ③ VISUAL DEV | PLAN → EXECUTE PREP | `Read ${CLAUDE_SKILL_DIR}/references/visual-development.md` | Turn plan into concrete anchors |
+| ④ PROMPTS | EXECUTE PREP | `Read ${CLAUDE_SKILL_DIR}/references/stage-prompts.md` | Convert frozen plan into prompt package |
+| ⑤⑥ GENERATE + ASSEMBLE | EXECUTE | `Read ${CLAUDE_SKILL_DIR}/references/stage-generate.md` | Run generation, review, assemble |
 
-Additional references loaded on-demand:
+Additional references loaded on demand:
 
 | Topic | Reference |
 |-------|-----------|
 | Story craft | `${CLAUDE_SKILL_DIR}/references/story-development.md` |
 | Coherence checks | `${CLAUDE_SKILL_DIR}/references/coherence-checklist.md` |
 | Style options | `${CLAUDE_SKILL_DIR}/references/style-library.md` |
-| Continuity across clips | `${CLAUDE_SKILL_DIR}/references/continuity-guide.md` |
+| Continuity / handoff | `${CLAUDE_SKILL_DIR}/references/continuity-guide.md` |
 | E-com prompt writing | `${CLAUDE_SKILL_DIR}/references/ecom-prompt-guide.md` |
 | Narrative pacing | `${CLAUDE_SKILL_DIR}/references/narrative-pacing.md` |
 | Retry & quality review | `${CLAUDE_SKILL_DIR}/references/retry-strategies.md` |
@@ -74,62 +126,50 @@ Additional references loaded on-demand:
 
 ## Modes
 
-| Mode | Trigger | Clips | Confirms | Stages |
-|------|---------|-------|----------|--------|
+| Mode | Trigger | Clips | Confirms | Stage Path |
+|------|---------|-------|----------|------------|
 | **A** Quick | Simple concept, ≤15s | 1 | 1 | ①→②→④→⑤ |
-| **B** E-com | "TikTok/product video" + product images | 1-3 | 2 | ①→②→④→⑤ |
-| **C** Original | "Short film/drama", original story, >15s | N | 3 | ①→②→③→④→⑤→⑥ |
-| **D** Adaptation | Source material (novel/screenplay/manga) | N | 3 | ①→②→③→④→⑤→⑥ |
-| **E** Montage | "MV/montage/mood piece", non-narrative | N | 2-3 | ①→②→③→④→⑤→⑥ |
+| **B** E-com | Product / sales / TikTok + product material | 1-3 | 2 | ①→②→④→⑤ |
+| **C** Original | Original story, drama, short film, >15s | N | 3 | ①→②→③→④→⑤→⑥ |
+| **D** Adaptation | Novel / screenplay / manga / source material | N | 3 | ①→②→③→④→⑤→⑥ |
+| **E** Montage | MV / montage / mood piece | N | 2-3 | ①→②→③→④→⑤→⑥ |
 
 ### Depth per Mode
 
 | Stage | A | B | C | D | E |
 |-------|---|---|---|---|---|
-| ① INTAKE | brief | product imgs | brief | source text | brief + refs |
+| ① INTAKE | brief | product-focused | brief | source-focused | brief + refs |
 | ② SCRIPT | micro-check | micro-story | logline + treatment | select + condense | beat sheet |
-| ③ VISUAL DEV | skip | product analysis | char + scene + storyboard | char + scene + storyboard | mood palette + scene refs |
-| ④ PROMPTS | 1 prompt | 1–3 prompts | N prompts + rhythm | N prompts + rhythm | N prompts + rhythm |
-| ⑤ GENERATE | 1 clip | 1–3 clips | N clips (strategy) | N clips (strategy) | N clips (parallel) |
-| ⑥ ASSEMBLE | skip | skip | concat + BGM | concat + BGM | concat + BGM |
-
-### Confirmation Points
-
-| Mode | Confirm ① | Confirm ② | Confirm ③ |
-|------|-----------|-----------|-----------|
-| A | prompt → generate | — | — |
-| B | product analysis | prompts → generate | — |
-| C | logline + treatment | visual dev results | shot table → generate |
-| D | scene selection + treatment | visual dev results | shot table → generate |
-| E | beat sheet + mood | visual dev results | shot table → generate |
+| ③ VISUAL DEV | skip | usually skip | char + scene + storyboard | char + scene + storyboard | mood + scene refs |
+| ④ PROMPTS | 1 prompt | 1-3 prompts | N prompts + continuity | N prompts + continuity | N prompts + continuity |
+| ⑤ GENERATE | 1 clip | 1-3 clips | N clips | N clips | N clips |
+| ⑥ ASSEMBLE | skip | skip | concat + polish | concat + polish | concat + polish |
 
 ---
 
-## Quick Flows
+## Confirmation Points
 
-```
-Mode A (1 clip, 1 confirm):
-  INTAKE → micro-check → prompt → [confirm] → generate
+| Mode | Confirm ① | Confirm ② | Confirm ③ |
+|------|-----------|-----------|-----------|
+| A | plan + prompt package | — | — |
+| B | product analysis + micro-story | prompt package | — |
+| C | logline + treatment + asset plan | anchor plan / visual dev | shot table + prompt package |
+| D | scene selection + treatment + asset plan | anchor plan / visual dev | shot table + prompt package |
+| E | beat sheet + mood | anchor plan / visual dev | shot table + prompt package |
 
-Mode B (1–3 clips, 2 confirms):
-  INTAKE + product analysis → [confirm①]
-  → micro-story + prompts → [confirm②] → generate
+**Trust level can reduce how much you explain, but it does not remove required planning artifacts.**
 
-Mode C (N clips, 3 confirms):
-  INTAKE → logline + treatment → [confirm①]
-  → VISUAL DEV (char + scene + storyboard + asset register) → [confirm②]
-  → shot table + prompts → [confirm③] → generate → assemble
+---
 
-Mode D (N clips, 3 confirms):
-  INTAKE (source text) → select + condense → [confirm①]
-  → VISUAL DEV (char + scene + storyboard + asset register) → [confirm②]
-  → shot table + prompts → [confirm③] → generate → assemble
+## Behavior Rules
 
-Mode E (N clips, 2–3 confirms):
-  INTAKE → beat sheet + mood → [confirm①]
-  → VISUAL DEV (mood palette + scene refs) → [confirm②]
-  → prompts → [confirm③ optional] → generate → assemble
-```
+- Do not skip a stage just because a later step feels obvious.
+- Do not start prompt finalization or generation while unresolved blockers remain.
+- If a required anchor is missing, return to PLAN / VISUAL DEV instead of improvising.
+- Required anchors are not limited to characters; environments, products, props, and continuity handoffs can be blocking too.
+- If continuity matters across clips, define the handoff state explicitly rather than relying on the model to guess.
+- When in doubt, prefer stronger anchors over more ornate prompts.
+- Story coherence and continuity beat visual flourishes.
 
 ---
 
@@ -137,24 +177,22 @@ Mode E (N clips, 2–3 confirms):
 
 | Error | Cause | Solution |
 |-------|-------|----------|
-| `PrivacyInformation` | ref_image contains human faces | Register as User Asset (`asset register`) → use `asset:ID:reference_image`. Or use Character Library. |
+| `PrivacyInformation` | Face in raw `ref_image` | Register as User Asset or use Character Library |
 | Insufficient credits (402) | Balance too low | `credit me`, inform user, suggest top-up at https://www.renoise.ai |
-| Task `failed` | Generation failed | `task get <id>` to check error. Adjust prompt and retry. See `retry-strategies.md`. |
-| Character drifts between segments | Abbreviated description or no visual anchor | Full Bible verbatim + register character image as User Asset |
-| Segments don't connect visually | No visual anchoring between parallel clips | Use storyboard grid as ref_image; add cross-dissolve in post |
-| Story feels disjointed | Causal chain broken | Re-run coherence check; ensure THEREFORE/BUT links |
-| Video looks incoherent | Prompt too complex | Reduce to 2-3 camera stages. One mood per segment |
+| Task `failed` | Server issue / policy / bad prompt | `task get <id>`, simplify or adjust, retry |
+| Character drifts | Weak or missing face anchor | Full Character Bible + asset / character anchoring |
+| Scene drifts | Weak or missing environment anchor | Add scene refs / storyboard panels / stronger continuity plan |
+| Clips do not connect | Handoff state not planned | Return to continuity plan, decide serial vs parallel |
+| Video incoherent | Prompt carries too many actions | Simplify beats and camera staging |
 
-For structured retry/fix workflows, see: `Read ${CLAUDE_SKILL_DIR}/references/retry-strategies.md`
+For retry patterns: `Read ${CLAUDE_SKILL_DIR}/references/retry-strategies.md`
 
 ---
 
 ## Performance Notes
 
-- Simpler prompts produce better results than complex ones
-- Default camera pattern when in doubt: push in → hold → pull back
-- 2-3 camera stages per 15s is the sweet spot
-- **Visual anchoring > text description** for character consistency
-- **Register character images as User Assets BEFORE writing prompts** — for ALL characters in 2+ segments, not just the protagonist
-- **Story coherence > visual polish** — a clear story told simply beats a complex story told confusingly
-- **Iterate on story/beat structure before prompt details** — fixing a blueprint costs 5 minutes; regenerating videos costs credits and 30+ minutes
+- Simpler prompts usually beat overloaded prompts
+- Fixing a plan is cheaper than regenerating clips
+- For multi-clip work, strong anchors matter more than elegant prose
+- Reuse exact character and lighting language; do not paraphrase casually
+- If a continuous scene must connect tightly, prefer serial / `ref_video` over wishful parallel generation

--- a/skills/director/examples/mystery-package-4shot.md
+++ b/skills/director/examples/mystery-package-4shot.md
@@ -1,19 +1,28 @@
-# Example: Mystery Package — 4-Shot Short Film
+# Example: Mystery Package — 4 × 15s Short Film
 
-A complete walkthrough of the 6-phase workflow for a 45-second suspense short film.
+A compact example of the new **Plan → Execute** workflow for a suspense short.
 
-## Phase 1 — Story & Character Bible
+---
 
-### Story Concept
-Maya comes home to find a mysterious package at her door. Inside is an antique pocket watch that glows when she holds it. As she examines it, the watch hands start spinning backwards and the room fills with golden light.
+## PLAN
 
-### Story Structure
-- **Beginning** (8s): Maya discovers the package
-- **Development** (13s): She opens it, finds the watch
-- **Climax** (12s): The watch activates, supernatural event
-- **Resolution** (12s): Aftermath, sense of wonder
+### 1. Project Summary
 
-### Character Bible
+**Concept**
+Maya comes home to find a mysterious package at her door. Inside is an antique pocket watch. When she opens it, the watch awakens and floods the room with golden light.
+
+**Mode**
+C — Original multi-clip short film
+
+**Format**
+4 clips × 15s = 60s total
+
+**Style Direction**
+Cinematic suspense drama, shallow depth of field, subtle film grain, warm amber tones with cool blue shadows, golden magical climax.
+
+---
+
+### 2. Character Bible
 
 ```json
 [
@@ -28,233 +37,180 @@ Maya comes home to find a mysterious package at her door. Inside is an antique p
 ]
 ```
 
-### Style Guide
+---
 
-```json
-{
-  "visual_style": "Cinematic suspense drama, shallow depth of field, subtle film grain, anamorphic lens flares",
-  "color_palette": "Warm amber tones with cool blue shadows, muted saturation shifting to warm gold in climax",
-  "lighting": "Soft golden hour side-lighting through large windows, practical lamps as warm fill, cool blue ambient from hallway",
-  "camera_language": "Slow deliberate movements, lingering close-ups, occasional wide establishing shots, push-ins for tension",
-  "negative_prompts": "No cartoon, no anime, no oversaturated colors, no dutch angles, no text overlays, no watermarks, no horror, no jump scares"
-}
+### 3. Segment Purpose Table
+
+| Segment | Story Function | Emotion | Key Location | Continuity Importance |
+|---------|----------------|---------|--------------|-----------------------|
+| S1 | setup | curiosity | apartment hallway | medium |
+| S2 | discovery | wonder | living room / desk | high |
+| S3 | escalation | awe / shock | same living room | very high |
+| S4 | resolution | wonder / calm | same living room | high |
+
+---
+
+### 4. Treatment
+
+**S1** — Maya walks down her apartment hallway with grocery bags and notices a brown-paper-wrapped package on her doormat. She kneels, picks it up, and studies it with cautious curiosity.
+
+**S2** — Inside her living room, she unwraps the package at a desk lit by a warm lamp and discovers an ornate gold pocket watch in a velvet box. She lifts it toward the light, captivated.
+
+**S3** — The watch hands spin backward. Golden light leaks from the face, then bursts outward, filling the room with warm particles as Maya rises in amazement.
+
+**S4** — The magical glow settles into a gentle pulse. Maya places the watch on the desk, steps back, and realizes she has just encountered something impossible.
+
+---
+
+### 5. Character Asset Plan
+
+| Character | Segments | Asset Strategy | Justification |
+|-----------|----------|----------------|---------------|
+| Maya | S1-S4 | ✅ Generate Asset | Appears in all 4 segments |
+
+---
+
+### 6. Anchor Needs Summary
+
+- **Character anchor needed**: Maya
+- **Environment anchors needed**: hallway, living room
+- **Object anchor recommended**: pocket watch close-up reference if available
+- **Strong continuity needed**: S2→S3, S3→S4
+- **Parallel-safe**: S1→S2 only
+
+---
+
+### 7. Plan Freeze Summary
+
+```md
+Mode: C
+Segments: 4 × 15s
+Style line: Cinematic suspense drama, shallow depth of field, subtle film grain, anamorphic lens flares. Warm amber tones with cool blue shadows, muted saturation shifting to warm gold in the climax. Soft golden hour side-lighting through large windows, practical lamps as warm fill.
+
+Blocking needs before execute:
+- Maya face anchor
+- hallway scene anchor
+- living room scene anchor
+- continuity strategy for S2→S3 and S3→S4
 ```
 
-## Phase 2 — Music & Beat Analysis
+---
 
-### Music Selection
-AI-generated via Suno with prompt: "Cinematic suspense, slow build, mysterious piano with subtle strings, 90 BPM, 45 seconds, rising tension to warm resolution"
+## EXECUTE PREP
 
-### Beat Analysis Output
+### 8. Visual Dev Outputs
 
-```json
-{
-  "bpm": 92,
-  "total_duration_s": 46.2,
-  "beats": [0.65, 1.30, 1.96, 2.61, 3.26, 3.91, ...],
-  "sections": [
-    { "start": 0, "end": 8.5, "label": "intro" },
-    { "start": 8.5, "end": 22.0, "label": "verse" },
-    { "start": 22.0, "end": 34.5, "label": "chorus" },
-    { "start": 34.5, "end": 46.2, "label": "outro" }
-  ],
-  "suggested_cuts": [
-    { "time": 0, "end": 8.5, "duration": 8.5, "section": "intro" },
-    { "time": 8.5, "end": 22.0, "duration": 13.5, "section": "verse" },
-    { "time": 22.0, "end": 34.5, "duration": 12.5, "section": "chorus" },
-    { "time": 34.5, "end": 46.2, "duration": 11.7, "section": "outro" }
-  ]
-}
+#### Anchor Registry
+
+| Character | Segments | Anchor Strategy | Asset ID | Notes |
+|-----------|----------|-----------------|----------|-------|
+| Maya | S1-S4 | User Asset | asset:27 | generated from character sheet |
+
+#### Scene / Environment Anchor Plan
+
+| Environment | Segments | Anchor Strategy | Material ID | Notes |
+|-------------|----------|-----------------|-------------|-------|
+| Hallway | S1 | scene ref | material:53 | warm apartment corridor |
+| Living room | S2-S4 | scene ref | material:61 | desk, lamp, window |
+| Storyboard grid | S1-S4 | shared visual DNA | material:72 | optional panel split |
+
+#### Continuity Strategy Table
+
+| Transition | Continuity Need | Strategy | Why |
+|------------|------------------|----------|-----|
+| S1→S2 | medium | parallel + continuity text | location change |
+| S2→S3 | high | serial / ref_video | same room, direct continuation |
+| S3→S4 | high | serial / ref_video | same room, magical aftermath |
+
+#### Shot → Anchor Mapping
+
+| Shot | Character Anchor | Scene Anchor | Extra Anchor | Strategy |
+|------|------------------|--------------|--------------|----------|
+| S1 | asset:27 | material:53 | material:72 | parallel |
+| S2 | asset:27 | material:61 | material:72 | parallel |
+| S3 | asset:27 | material:61 | ref_video from S2 | serial |
+| S4 | asset:27 | material:61 | ref_video from S3 | serial |
+
+---
+
+### 9. Shot Table with Handoff States
+
+| Shot | Opening State | Closing State |
+|------|---------------|---------------|
+| S1 | Maya enters hallway carrying grocery bags | Maya at apartment door holding wrapped package at chest height |
+| S2 | Maya enters living room still holding package | Maya seated at desk, holding opened pocket watch up to lamp |
+| S3 | Maya seated with watch raised near her face | Maya standing, both hands cupping glowing watch in a room full of golden particles |
+| S4 | Maya standing in golden-lit room holding glowing watch | Maya steps back from desk as watch pulses softly on tabletop |
+
+---
+
+## FINAL PROMPT PACKAGE
+
+### Global Style Line
+
+```text
+Cinematic suspense drama, shallow depth of field, subtle film grain, anamorphic lens flares. Warm amber tones with cool blue shadows, muted saturation shifting to warm gold in the climax. Soft golden hour side-lighting through large windows, practical lamps as warm fill.
 ```
 
-### Finalized Shot Durations
-- S1: 8s (intro) — rounded down from 8.5s
-- S2: 13s (verse) — rounded down from 13.5s
-- S3: 12s (chorus) — rounded down from 12.5s
-- S4: 12s (outro) — rounded up from 11.7s
+### Example Prompt — S2
 
-## Phase 3 — Shot Table
+```text
+Cinematic suspense drama, shallow depth of field, subtle film grain, anamorphic lens flares. Warm amber tones with cool blue shadows, muted saturation shifting to warm gold in the climax. Soft golden hour side-lighting through large windows, practical lamps as warm fill.
 
-### S1 — Discovery (8s, intro)
-
-| Field | Value |
-|-------|-------|
-| scene | Dimly lit apartment hallway, warm overhead pendant light, beige walls, mailboxes on the left, Maya's door at the end |
-| characters | CHAR_MAYA |
-| action | Maya walks down hallway carrying grocery bags, notices a small wrapped package on her doormat, sets bags down, picks up the package with both hands, looks at it curiously |
-| camera | [0-3s] Medium tracking shot following Maya from behind. [3-5s] Over-shoulder angle as she bends to set bags down. [5-8s] Slow push-in to her hands picking up the package, then to her face. |
-| dialogue | [2s] (keys jingling) [5s] "Hmm... what's this?" [7s] (paper crinkling) |
-| beat_sync_notes | Beat 4 (2.6s) = Maya spots the package; Beat 8 (5.2s) = hands close around package |
-| continuity_in | null |
-| continuity_out | Standing at apartment doorway, both hands holding small wrapped package at chest height, curious expression with slight head tilt, warm pendant light from above casting soft shadows, grocery bags on floor beside her |
-
-### S2 — The Watch (13s, verse)
-
-| Field | Value |
-|-------|-------|
-| scene | Maya's apartment living room, warm table lamp on wooden desk, large window with twilight blue light, cozy cluttered space with books and plants |
-| characters | CHAR_MAYA |
-| action | Maya sits at desk, carefully unwraps the brown paper to reveal a worn velvet box, opens it to find an ornate gold pocket watch with intricate engravings, lifts it out, holds it up to the lamp light, the watch face catches the light beautifully |
-| camera | [0-4s] Medium shot of Maya sitting down at desk, setting package on it. [4-8s] Close-up of her hands unwrapping. [8-11s] Macro shot of watch being lifted from velvet box. [11-13s] Medium close-up of Maya holding watch up to lamp, wonder in her eyes. |
-| dialogue | [3s] "Let me see..." [6s] (paper tearing slowly) [9s] (soft gasp) "Oh..." [12s] "It's beautiful..." |
-| beat_sync_notes | Beat 2 (1.3s) = paper tearing begins; Beat 8 (5.2s) = box lid opens; Beat 12 (7.8s) = watch lifted from box |
-| continuity_in | Standing at apartment doorway, both hands holding small wrapped package at chest height, curious expression with slight head tilt, warm pendant light from above casting soft shadows, grocery bags on floor beside her |
-| continuity_out | Seated at wooden desk, right hand holding gold pocket watch up at eye level, left hand resting on desk, warm amber lamp light reflecting off watch face, twilight blue from window behind her, expression of quiet wonder |
-
-### S3 — Activation (12s, chorus)
-
-| Field | Value |
-|-------|-------|
-| scene | Same apartment living room, but lighting shifts — the gold pocket watch begins emitting a warm golden glow, gradually filling the room with golden light particles |
-| characters | CHAR_MAYA |
-| action | Maya turns the watch over in her hands, the watch hands begin spinning backwards rapidly, a warm golden light emanates from the watch face, light particles float upward from the watch, Maya's eyes widen in shock then fascination, the golden glow intensifies filling the room |
-| camera | [0-3s] Extreme close-up of watch face, hands starting to spin. [3-6s] Pull back to medium shot as golden light begins emanating. [6-9s] Low angle looking up at Maya with golden particles floating around her. [9-12s] Wide shot of the entire room bathed in golden light, Maya at center. |
-| dialogue | [2s] "Wait... the hands are..." [5s] (mechanical ticking accelerating) [8s] (awed whisper) "Oh my god..." |
-| beat_sync_notes | Beat 1 (0.65s) = watch hands start spinning; Beat 6 (3.9s) = golden light burst; Beat 10 (6.5s) = room fully illuminated |
-| continuity_in | Seated at wooden desk, right hand holding gold pocket watch up at eye level, left hand resting on desk, warm amber lamp light reflecting off watch face, twilight blue from window behind her, expression of quiet wonder |
-| continuity_out | Standing up from desk (chair pushed back), both hands cupping the glowing watch at chest level, entire room bathed in warm golden light with floating particles, Maya's face illuminated gold, expression of awe and wonder, eyes reflecting golden light |
-
-### S4 — Wonder (12s, outro)
-
-| Field | Value |
-|-------|-------|
-| scene | Apartment living room, golden light slowly fading back to warm amber, particles settling like golden dust, the watch glow softens to a gentle pulse |
-| characters | CHAR_MAYA |
-| action | Maya slowly lowers the watch, the golden light fades to a gentle pulsing glow from the watch face, she looks around the room in wonder at the settling golden dust, gently places the watch on the desk, steps back, the watch pulses once more with a soft glow, she smiles with a mix of wonder and excitement |
-| camera | [0-3s] Close-up of Maya's illuminated face, golden light fading. [3-6s] Medium shot as she lowers the watch, golden particles settling around her. [6-9s] Over-shoulder shot as she places watch on desk. [9-12s] Final wide shot of room, Maya standing, watch pulsing gently on desk, warm amber atmosphere. |
-| dialogue | [3s] (gentle exhale) [6s] "What are you..." [10s] (soft, wondering smile — no words) |
-| beat_sync_notes | Beat 3 (1.95s) = golden light begins fading; Beat 8 (5.2s) = watch placed on desk; Final beat (11s) = last pulse of light |
-| continuity_in | Standing up from desk (chair pushed back), both hands cupping the glowing watch at chest level, entire room bathed in warm golden light with floating particles, Maya's face illuminated gold, expression of awe and wonder, eyes reflecting golden light |
-| continuity_out | Standing 2 steps back from desk, hands at sides, warm amber room lighting restored, gold pocket watch on desk pulsing with gentle glow, expression of wonder and quiet excitement, evening twilight through window |
-
-## Phase 4 — Seedance Prompts
-
-### S1 Prompt
-
-```
-Cinematic suspense drama, shallow depth of field, subtle film grain, anamorphic lens flares. Warm amber tones with cool blue shadows, muted saturation. Soft golden hour side-lighting through large windows, practical lamps as warm fill, cool blue ambient from hallway.
+Continuing from the previous shot: Maya has just entered her living room carrying a small brown-paper-wrapped package in both hands, curious and cautious, warm hallway light behind her and a wooden desk with a table lamp ahead.
 
 Character: East Asian woman, late 20s, shoulder-length black hair with subtle auburn highlights, warm ivory skin, almond-shaped dark brown eyes, slim build. Wearing oversized cream-colored chunky-knit wool cardigan over a fitted charcoal cotton turtleneck, high-waisted dark indigo straight-leg jeans, brown leather ankle boots. Small gold hoop earrings, thin gold chain bracelet on left wrist, no rings.
 
-[0-3s] Medium tracking shot following Maya from behind as she walks down a dimly lit apartment hallway carrying grocery bags. Warm pendant light overhead, beige walls, mailboxes on the left. At 2.6s (on the beat): she spots a small wrapped package on her doormat and slows.
+Follow the character appearance from the reference image. Match the living room environment from the reference image.
 
-[3-5s] Over-shoulder angle as she bends to set grocery bags on the floor beside the door. Natural, unhurried movement.
+[0-5s] Medium shot as Maya crosses to a wooden desk in a cozy living room, sets the package down, and sits. Warm table lamp on the desk, large window behind her with twilight blue light.
 
-[5-8s] Slow push-in as her hands pick up the small brown-paper-wrapped package. At 5.2s (on the beat): her fingers close around it. She lifts it to chest height and tilts her head with curiosity. At 5s she says "Hmm... what's this?" softly.
+[5-10s] Close-up of her hands unwrapping the brown paper to reveal a worn velvet box. She opens it and discovers an ornate gold pocket watch with engraved details.
 
-Avoid: No cartoon, no anime, no oversaturated colors, no dutch angles, no text overlays, no watermarks, no horror, no jump scares.
+[10-15s] Medium close-up as she lifts the watch toward the lamp. The metal catches warm amber light and her face softens into quiet wonder.
+
+Spoken dialogue (say EXACTLY, word-for-word): "It's beautiful..."
+Tone: hushed wonder. Mouth clearly visible when speaking, lip-sync aligned.
+
+Sound design: soft paper crinkle, gentle room tone, faint metallic ticking.
+Avoid: no cartoon, no anime, no oversaturated colors, no dutch angles, no text overlays, no watermarks, no horror, no jump scares.
 ```
 
-### S2 Prompt
+### Prompt-to-Anchor Mapping
 
-```
-Cinematic suspense drama, shallow depth of field, subtle film grain, anamorphic lens flares. Warm amber tones with cool blue shadows, muted saturation. Soft golden hour side-lighting through large windows, practical lamps as warm fill, cool blue ambient from hallway.
-
-Continuing from the previous shot: Standing at apartment doorway, both hands holding small wrapped package at chest height, curious expression with slight head tilt, warm pendant light from above casting soft shadows, grocery bags on floor beside her.
-
-Character: East Asian woman, late 20s, shoulder-length black hair with subtle auburn highlights, warm ivory skin, almond-shaped dark brown eyes, slim build. Wearing oversized cream-colored chunky-knit wool cardigan over a fitted charcoal cotton turtleneck, high-waisted dark indigo straight-leg jeans, brown leather ankle boots. Small gold hoop earrings, thin gold chain bracelet on left wrist, no rings.
-
-[0-4s] Medium shot of Maya walking into her apartment living room and sitting down at a wooden desk with a warm table lamp. She places the package on the desk. Large window behind her shows twilight blue light. At 1.3s (on the beat): she begins pulling at the brown paper wrapping.
-
-[4-8s] Close-up of her hands carefully unwrapping the brown paper to reveal a worn navy velvet box. At 5.2s (on the beat): the box lid opens to reveal an ornate gold pocket watch with intricate engravings. At 6s she whispers "Let me see..."
-
-[8-11s] Macro shot of the gold pocket watch being lifted from the velvet box. Intricate engravings catch the warm lamp light. At 7.8s (on the beat): Maya lifts it free. She gasps softly "Oh..." at 9s.
-
-[11-13s] Medium close-up of Maya holding the pocket watch up to the lamp at eye level. Warm amber light reflects off the watch face. Her expression is quiet wonder. She says "It's beautiful..." at 12s.
-
-Avoid: No cartoon, no anime, no oversaturated colors, no dutch angles, no text overlays, no watermarks, no horror, no jump scares.
+```text
+S1 → --materials "asset:27:reference_image" --materials "53:ref_image"
+S2 → --materials "asset:27:reference_image" --materials "61:ref_image"
+S3 → --materials "asset:27:reference_image" --materials "88:ref_video"
+S4 → --materials "asset:27:reference_image" --materials "94:ref_video"
 ```
 
-### S3 Prompt
+---
 
-```
-Cinematic suspense drama, shallow depth of field, subtle film grain, anamorphic lens flares. Warm amber tones with cool blue shadows, muted saturation shifting to warm gold in climax. Soft golden hour side-lighting through large windows, practical lamps as warm fill.
-
-Continuing from the previous shot: Seated at wooden desk, right hand holding gold pocket watch up at eye level, left hand resting on desk, warm amber lamp light reflecting off watch face, twilight blue from window behind her, expression of quiet wonder.
-
-Character: East Asian woman, late 20s, shoulder-length black hair with subtle auburn highlights, warm ivory skin, almond-shaped dark brown eyes, slim build. Wearing oversized cream-colored chunky-knit wool cardigan over a fitted charcoal cotton turtleneck, high-waisted dark indigo straight-leg jeans, brown leather ankle boots. Small gold hoop earrings, thin gold chain bracelet on left wrist, no rings.
-
-[0-3s] Extreme close-up of the gold pocket watch face. At 0.65s (on the beat): the watch hands begin spinning backwards rapidly. Mechanical ticking sound accelerates. The ornate engravings shimmer. Maya whispers at 2s "Wait... the hands are..."
-
-[3-6s] Pull back to medium shot. At 3.9s (on the beat): a warm golden light bursts from the watch face. Golden light particles begin floating upward from the watch. The amber room lighting intensifies to golden.
-
-[6-9s] Low angle looking up at Maya. Golden particles float all around her like luminous dust motes. At 6.5s (on the beat): the entire room is bathed in golden light. She stands up slowly from the desk, cupping the watch in both hands. At 8s she whispers in awe "Oh my god..."
-
-[9-12s] Wide shot of the entire living room transformed by golden light. Maya at center, standing, both hands cupping the glowing watch at chest level. Golden particles fill the air like a supernatural snowfall. Her face is illuminated in pure gold.
-
-Avoid: No cartoon, no anime, no oversaturated colors, no dutch angles, no text overlays, no watermarks, no horror, no jump scares.
-```
-
-### S4 Prompt
-
-```
-Cinematic suspense drama, shallow depth of field, subtle film grain, anamorphic lens flares. Warm amber tones with cool blue shadows, muted saturation. Soft golden hour side-lighting through large windows, practical lamps as warm fill.
-
-Continuing from the previous shot: Standing up from desk (chair pushed back), both hands cupping the glowing watch at chest level, entire room bathed in warm golden light with floating particles, Maya's face illuminated gold, expression of awe and wonder, eyes reflecting golden light.
-
-Character: East Asian woman, late 20s, shoulder-length black hair with subtle auburn highlights, warm ivory skin, almond-shaped dark brown eyes, slim build. Wearing oversized cream-colored chunky-knit wool cardigan over a fitted charcoal cotton turtleneck, high-waisted dark indigo straight-leg jeans, brown leather ankle boots. Small gold hoop earrings, thin gold chain bracelet on left wrist, no rings.
-
-[0-3s] Close-up of Maya's face bathed in golden light. At 1.95s (on the beat): the golden light begins slowly fading. The golden particles start drifting downward like settling dust. A gentle exhale at 3s.
-
-[3-6s] Medium shot as Maya slowly lowers the watch from chest height. Golden particles settle around her like luminous dust. The room's warm amber lighting gradually returns to normal. She looks around the room in wonder. At 6s she whispers "What are you..."
-
-[6-9s] Over-shoulder shot as she gently places the gold pocket watch on the wooden desk. At 5.2s (on the beat): the watch touches the desk surface. The glow from the watch face softens to a gentle pulse. Table lamp and twilight window light return to dominance.
-
-[9-12s] Final wide shot of the apartment living room. Maya stands two steps back from the desk, hands at her sides. The gold pocket watch on the desk pulses once more with soft golden light. At 11s (final beat): the last gentle pulse. Maya smiles with quiet wonder and excitement. Warm amber evening atmosphere, twilight through the window.
-
-Avoid: No cartoon, no anime, no oversaturated colors, no dutch angles, no text overlays, no watermarks, no horror, no jump scares.
-```
-
-## Phase 5 — Generation
+## GENERATION STRATEGY
 
 ### Cost Estimate
 
-```
-S1 (8s):  ~4 credits
-S2 (13s): ~6 credits
-S3 (12s): ~6 credits
-S4 (12s): ~6 credits
-Total:    ~22 credits
-```
+- 4 video clips × ~300 credits = ~1200 credits
+- 1 character sheet + 2 scene refs + storyboard grid = ~200 credits range
+- total planning budget target: ~1400 credits
 
-### Batch Command
+### Execution Plan
 
-```bash
-bash batch-generate.sh \
-  --project mystery-package \
-  --ratio 16:9 \
-  --prompts-file prompts.json
-```
+1. Generate Maya character sheet → register as `asset:27`
+2. Generate hallway and living room scene refs
+3. Generate S1 and S2
+4. Use S2 output as `ref_video` for S3
+5. Use S3 output as `ref_video` for S4
+6. Review each clip before assembly
+7. Concatenate and add unified BGM in post
 
-## Phase 6 — Assembly Guide
+---
 
-### Clip Summary
+## WHY THIS EXAMPLE MATTERS
 
-| Shot | Duration | Section | Key Moment |
-|------|----------|---------|------------|
-| S1   | 8s       | intro   | Maya discovers package |
-| S2   | 13s      | verse   | Opens watch |
-| S3   | 12s      | chorus  | Watch activates, golden light |
-| S4   | 12s      | outro   | Light fades, wonder remains |
-
-### Transitions
-
-- S1 → S2: **Cross dissolve** (0.5s) — location change from hallway to living room
-- S2 → S3: **Hard cut** — same location, continuous action
-- S3 → S4: **Hard cut** — same location, continuous action
-
-### BGM Instructions
-
-1. Import all 4 clips sequentially in CapCut/Premiere/DaVinci
-2. Mute all AI-generated audio tracks
-3. Place `bgm.aac` on the audio timeline starting at 0:00
-4. S1 starts at 0:00, S2 at 8s, S3 at 21s, S4 at 33s
-5. Keep any natural SFX you like (paper crinkling, ticking) by un-muting selectively
-6. Export 16:9, 30fps, H.264
-
-### Color Grading Notes
-
-Apply a unified LUT or color grade across all clips to ensure:
-- Consistent skin tones for Maya across all 4 clips
-- Smooth color temperature transitions (cool hallway → warm room → golden climax → warm resolution)
-- Match the amber/blue shadow palette from the Style Guide
+This example follows the new workflow:
+- plan is frozen before generation
+- anchors are decided before prompt writing
+- continuity-critical transitions are marked as serial instead of guessed
+- all clips remain 15 seconds, matching the platform rule

--- a/skills/director/references/continuity-guide.md
+++ b/skills/director/references/continuity-guide.md
@@ -1,216 +1,198 @@
 # Cross-Clip Continuity Guide
 
-Techniques for maintaining visual consistency across multiple Seedance 2.0 clips.
+Continuity is not just a prompt-writing trick. It is a **handoff design problem**.
 
-## Character Description Rules
+For multi-clip work, continuity should be planned before execution, then reinforced in prompts and generation strategy.
+
+---
+
+## 1. Plan Continuity First
+
+Before writing final prompts, define continuity where it matters.
+
+Use a table like this:
+
+```text
+| Transition | opening_state next shot | closing_state prior shot | Strategy | Notes |
+|------------|--------------------------|--------------------------|----------|-------|
+| S1→S2 | Maya enters living room holding package | Maya at doorway holding package | parallel + continuity text | location change |
+| S2→S3 | Maya seated with watch raised to lamp | Maya seated with watch raised to lamp | serial / ref_video preferred | same location, continuous action |
+```
+
+### What Belongs in a State Description
+- character position and orientation
+- prop state
+- emotional state
+- lighting state
+- important environment state
+- whether motion is ongoing or settled
+
+### What Does Not Belong
+- soundtrack notes
+- camera jargon that only applies to one shot
+- long exposition
+
+If a transition matters visually, plan it explicitly. Do not trust the model to infer the seam.
+
+---
+
+## 2. Choose the Right Continuity Strategy
+
+| Situation | Best Strategy |
+|-----------|---------------|
+| Same location + same character + continuous action | **Serial / ref_video** |
+| Same character, different location | **Parallel with strong face + scene anchors** |
+| Different characters / different places | **Parallel** |
+| Mixed project | **Hybrid** |
+
+The tighter the seam requirement, the less you should rely on prompt-only continuity.
+
+---
+
+## 3. Character Continuity Rules
 
 ### Copy Verbatim — Never Abbreviate
+The biggest cause of drift is paraphrasing.
 
-The #1 cause of character drift is paraphrasing. Every shot must include the **exact same character description** from the Character Bible.
-
-```
+```text
 WRONG:  "A young woman with black hair"
 RIGHT:  "East Asian woman, late 20s, shoulder-length black hair with subtle auburn highlights, warm ivory skin, almond-shaped dark brown eyes"
 ```
 
-Even small omissions cause drift. If the Bible says "shoulder-length black hair with subtle auburn highlights", every prompt must say exactly that.
+### Highest-Risk Drift Features
+1. hair color / length
+2. skin tone
+3. wardrobe color and cut
+4. apparent age
+5. signature accessories
 
-### Drift Vulnerability Ranking
-
-Features that drift most easily (highest risk first):
-
-1. **Hair color & length** — Most volatile. Always specify shade, length, and texture.
-2. **Skin tone** — Use specific terms ("warm ivory", "deep espresso brown"), not vague ones ("light", "dark").
-3. **Clothing color** — Must include texture + cut + color: "cream-colored chunky-knit wool cardigan" not "white sweater".
-4. **Age** — State explicitly: "late 20s" not "young woman".
-5. **Body type** — Least volatile but still specify if relevant.
-
-### Wardrobe Anchoring
-
-Three-part wardrobe description for every garment:
-
-```
-[texture/material] + [cut/style] + [color]
-
-"Oversized cream-colored chunky-knit wool cardigan"
- ↑ cut      ↑ color     ↑ texture/material  ↑ garment
-
-"Fitted charcoal cotton turtleneck"
- ↑ cut  ↑ color  ↑ material  ↑ garment
+### Wardrobe Anchoring Pattern
+Use:
+```text
+[texture/material] + [cut/style] + [color] + [garment]
 ```
 
-### Signature Details as Anchors
-
-Accessories and unique features act as visual anchors that help the model maintain identity:
-- Jewelry: "Small gold hoop earrings, thin gold chain bracelet on left wrist"
-- Tattoos: "Small constellation tattoo on inner right wrist"
-- Props: "Always carries a worn leather messenger bag"
-
-Include these in every prompt, even if not the focus of the shot.
-
-## Lighting Consistency
-
-### Same Scene = Same Light Words
-
-If shots S1 and S2 occur in the same location, use **identical lighting descriptors**:
-
+Example:
+```text
+oversized cream-colored chunky-knit wool cardigan
 ```
-S1: "Soft golden hour side-lighting through large windows, practical lamps as secondary fill"
-S2: "Soft golden hour side-lighting through large windows, practical lamps as secondary fill"
-```
-
-Never rephrase "golden hour side-lighting" as "warm natural light" — the model interprets these differently.
-
-### Cross-Scene Lighting
-
-Different locations can have different lighting, but the **color temperature** should stay consistent with the Style Guide. If the guide says "warm amber tones with cool blue shadows", every location should interpret this within that range.
-
-## Continuity Bridging
-
-### The Bridge Formula
-
-Every shot after S1 must begin with:
-
-```
-Continuing from the previous shot: [exact continuity_out from previous shot].
-```
-
-This is the single most important technique for visual coherence.
-
-### What to Include in continuity_out
-
-1. **Character position**: "Standing at doorway, facing camera at 3/4 angle"
-2. **Prop state**: "Both hands holding small wrapped package at chest height"
-3. **Emotional state**: "Curious expression, slight head tilt"
-4. **Lighting state**: "Warm pendant light from above, soft shadows on face"
-5. **Environmental state**: "Door is open behind her, hallway light visible"
-
-### What NOT to Include
-
-- Camera angles (the new shot may use a different angle)
-- Music cues (handled separately)
-- Dialogue (new shot has its own script)
-
-## Style Prefix Consistency
-
-### The Global Prefix
-
-Every prompt starts with the exact same style block:
-
-```
-[visual_style]. [color_palette]. [lighting].
-```
-
-This prefix is the #2 most important consistency tool after character descriptions.
-
-### Negative Prompts
-
-End every prompt with the same negative block:
-
-```
-Avoid: [negative_prompts from Style Guide].
-```
-
-## Transition Techniques
-
-### Hiding Inconsistency
-
-When character appearance inevitably drifts slightly between clips:
-
-1. **Whip pan / motion blur**: End one shot with fast camera movement, start next with fast movement. The blur hides the transition.
-2. **Close-up → Wide**: End on a face close-up, start the next shot wide. The scale change masks small differences.
-3. **Cut on action**: End mid-movement (hand reaching), start the next shot completing the movement. The viewer's eye follows the action, not appearance details.
-4. **Dark → Light**: End shot in shadow, start next in light. Lighting shift distracts from appearance changes.
-
-### The 80% Rule
-
-AI-generated clips will achieve ~80% visual consistency when following these techniques. The remaining 20% is handled in post-production:
-- Color grading to unify color palette
-- Subtle speed adjustments for timing
-- Audio continuity (shared BGM) creates perceived visual continuity
-
-## Face-Safe References (User Assets & Character Library)
-
-Two approaches for face consistency across clips, both bypass privacy detection:
-
-### Comparison
-
-| Method | Face Consistency | Privacy Detection | Setup | Best For |
-|--------|-----------------|-------------------|-------|----------|
-| **User Asset** (`asset:ID:reference_image`) | High — same face reference | ✅ Bypasses — `asset://` URI | ~1 min per character | AI-generated characters, new projects |
-| **Character Library** (`--characters "ID"`) | Highest — exact face every time | ✅ Bypasses — platform-registered | Requires platform setup | Pre-existing characters, real faces |
-| Grid Storyboard (`ref_image`) | Medium — shared context but may drift | ❌ **Often blocked** if faces visible | Quick to generate | Style/palette anchoring only |
-| Text-only description | Lowest — face drifts per generation | ✅ No images | Zero setup | Fallback, simple projects |
-
-### User Asset Workflow (recommended for AI-generated characters)
-
-1. Generate character design sheet with `nano-banana-2`
-2. Download → `material upload` → get material ID
-3. `asset register <material_id> --name "Character Name"` → wait ~30-60s → get asset ID
-4. Use `--materials "asset:ID:reference_image"` in every segment featuring that character
-5. Combine with text Character Bible for wardrobe/pose control
-
-### Character Library Workflow (for pre-existing platform characters)
-
-1. Create/find characters on https://www.renoise.ai
-2. `renoise character list` to find IDs
-3. Use `--characters "ID"` in every segment featuring that character
-4. Combine with text Character Bible for wardrobe/pose control
-
-### When to Use Which
-
-- **New original project, no existing characters** → User Asset (generate + register)
-- **Recurring platform characters** → Character Library
-- **Real person likeness** → Character Library (upload real photo on platform)
-- **Quick one-off, no face consistency needed** → Text-only
 
 ---
 
-## Grid Storyboard Method
+## 4. Environment Continuity Rules
 
-### Why One Image > Many Images
+If the same location appears again, reuse the same core lighting and environment language.
 
-When generating reference images for each shot independently (even with the same prompt style), each generation starts from a different random seed. This causes:
-- Slight differences in character face shape, eye size, hair texture
-- Color palette drift between shots
-- Inconsistent rendering style (more/less detailed, different line weights)
+```text
+S2: Soft golden hour side-lighting through large windows, practical lamps as warm fill.
+S3: Soft golden hour side-lighting through large windows, practical lamps as warm fill.
+```
 
-**The Grid Storyboard method solves this** by generating ALL shots in a single image. Because the AI renders all panels in one context:
-- Characters share the exact same face structure, proportions, and styling
-- Color palette is unified across all panels
-- Rendering technique (line weight, shading style, texture) is consistent
-- The AI "remembers" what it drew in Panel 1 when drawing Panel 8
+Do not casually rewrite the same environment as a new one.
 
-### ⚠️ Privacy Detection Warning
+If the location transforms, make the transformation explicit:
+- base environment stays the same
+- changed element is stated clearly
 
-Storyboard grids containing **close-up human faces** will likely trigger `PrivacyInformation` errors when used as `ref_image`. To avoid this:
-- Design grids with **environment-focused panels** (wide shots, small figures)
-- Use the **Character Library** for face consistency instead of relying on the grid
-- If the grid is blocked, fall back to **text-only** prompts with full Character Bible
+Example:
+```text
+Same living room as S2, but now filled with warm golden particles from the glowing watch.
+```
 
-### Workflow
+---
 
-1. Write a single prompt describing all panels with verbatim character descriptions
-2. Generate one grid image via `renoise-gen` (`nano-banana-2`)
-3. Split into individual panels: `bash split-grid.sh grid.png storyboard/ 2 4`
-4. Upload each panel as material for Image-to-Video generation
-5. Each Seedance clip now has a visual anchor from the same source
+## 5. Prompt-Level Continuity Bridge
 
-> **Best practice**: Use the grid for **style/palette/composition** anchoring, and the Character Library for **face** anchoring. These complement each other.
+When continuity matters, start later shots with a bridge like:
 
-### When to Use
+```text
+Continuing from the previous shot: [exact prior closing_state].
+```
 
-- **Recommended** for projects with recurring characters (but combine with Character Library for faces)
-- Especially important for anime/manga/stylized projects where character design must be exact
-- Less critical for pure environment/landscape shots with no characters
+This works best when the state was already planned.
 
-## Common Mistakes
+### Include
+- pose / placement
+- held objects
+- emotional tone
+- lighting state
+- relevant environment state
+
+### Avoid
+- restating the whole previous shot
+- camera instructions from the old shot
+- music cues
+
+---
+
+## 6. Style Prefix Consistency
+
+Keep the same global style block across related clips:
+
+```text
+[visual_style]. [color_palette]. [lighting].
+```
+
+And keep the same negative block:
+
+```text
+Avoid: [negative prompts].
+```
+
+This is one of the strongest non-reference continuity tools.
+
+---
+
+## 7. Reference Choices
+
+### Face Consistency
+| Method | Consistency | Best For |
+|--------|-------------|----------|
+| User Asset | High | new recurring characters |
+| Character Library | Highest | existing platform characters |
+| Text-only | Low | fallback only |
+
+### Environment / Composition Consistency
+| Method | Consistency | Best For |
+|--------|-------------|----------|
+| scene ref_image | High | recurring environments |
+| storyboard panel | Medium-High | shared visual DNA |
+| text-only | Low | fallback |
+
+### Motion / Seam Consistency
+| Method | Consistency | Best For |
+|--------|-------------|----------|
+| ref_video | Highest | direct shot-to-shot continuation |
+| continuity text only | Medium | softer handoffs |
+
+---
+
+## 8. Transition Tactics When Perfect Continuity Is Not Possible
+
+Useful tactics:
+1. cut on action
+2. motion blur / whip pan at seam
+3. close-up to wide change
+4. shadow-to-light or light-to-shadow shift
+5. short cross-dissolve in post
+
+These do not replace planning. They help hide residual mismatch.
+
+---
+
+## 9. Common Mistakes
 
 | Mistake | Fix |
 |---------|-----|
-| Abbreviating character descriptions | Copy the full Character Bible entry every time |
-| Rephrasing lighting descriptors | Use identical words for same-location lighting |
-| Forgetting continuity bridge | Always start S2+ with "Continuing from the previous shot:" |
-| Including BGM in Seedance prompt | Never mention music in video prompts — BGM is overlaid in post |
-| Using different style prefixes | Same prefix for every shot, character for character |
-| Describing camera in continuity_out | Continuity describes scene state, not camera state |
+| Abbreviating recurring character descriptions | Copy verbatim every time |
+| Treating every transition the same | Mark serial vs parallel in plan |
+| No closing_state / opening_state | Add handoff state before prompt writing |
+| Rephrasing the same environment repeatedly | Reuse the same core wording |
+| Using raw face `ref_image` | Register as asset or use Character Library |
+| Expecting prompt prose alone to solve seam continuity | Use stronger anchors or `ref_video` |
+
+---
+
+## Summary Rule
+
+**If the viewer should feel that two clips belong to the same continuous world or action, continuity must be designed before generation, not hoped for after generation.**

--- a/skills/director/references/stage-generate.md
+++ b/skills/director/references/stage-generate.md
@@ -1,101 +1,169 @@
-# Stage 5-6: GENERATE & ASSEMBLE
+# Stage 5-6: GENERATE & ASSEMBLE — EXECUTE
+
+This is the **EXECUTE** stage.
+
+Goal: run the approved prompt package, preserve planned continuity, review the outputs against the frozen plan, and assemble only after the clips are good enough.
+
+---
+
+## Execute Rule
+
+During execution, do not silently rewrite the plan.
+
+If you discover missing critical detail such as:
+- an unanchored recurring human
+- a missing environment reference
+- a missing product / prop anchor that the shot depends on
+- an unresolved transition strategy
+- a prompt that cannot faithfully represent the planned shot
+
+then **pause and return to PLAN / VISUAL DEV / PROMPTS** before continuing.
+
+---
 
 ## Stage 5: GENERATE
 
 ### Pre-Flight Check (BLOCKING)
 
-Before submitting ANY video task, verify:
+Before submitting any task, verify all of the following.
 
-1. **Character Asset Completeness**: Every character in 2+ segments has a registered asset with status `active`:
+#### 1. Plan Freeze Exists
+You have:
+- approved segment / shot table
+- prompt package
+- shot → anchor mapping
+- continuity strategy table for multi-clip work
+
+If not, stop.
+
+#### 2. Anchor Integrity Check
+Verify that all quality-critical anchors are resolved:
+- every recurring human has an active face-safe anchor
+- recurring environments have their planned anchors
+- recurring products / props have their planned anchors when required
+- shot → anchor mapping is complete
+
 ```bash
 node ${CLAUDE_PLUGIN_ROOT}/skills/renoise-gen/renoise-cli.mjs asset list --status active
 ```
-Cross-reference against the Character-to-Asset Registry from VISUAL DEV. If any 2+ segment character is missing an active asset, **STOP and go back to VISUAL DEV**.
+Cross-check against the Anchor Registry and Shot → Anchor Mapping.
 
-2. **Balance Check**:
+#### 3. Budget Check
 ```bash
 node ${CLAUDE_PLUGIN_ROOT}/skills/renoise-gen/renoise-cli.mjs credit me
 ```
 
-### Generation Strategy (Multi-Clip)
+#### 4. Continuity Strategy Check
+For each transition that needs tight continuity, confirm whether it is:
+- **serial / ref_video**
+- **parallel with strong anchors**
+- **hybrid**
 
-| Condition | Strategy | Speed |
-|-----------|----------|-------|
-| Same character + same location across segments | **Serial** (ref_video chain) | ~8 min × N |
-| Same character + different locations (has ref_image per shot) | **Parallel** | ~8 min total |
-| Different characters, different locations | **Parallel** | ~8 min total |
-| Mixed | **Hybrid** — serial within blocks, parallel between blocks | varies |
+Do not treat this as a cosmetic detail.
 
-### Execution
+---
 
-**Single clip (A, B):**
+## Generation Strategy
+
+| Condition | Strategy | Why |
+|-----------|----------|-----|
+| Same human + same location + continuous action | **Serial** (`ref_video`) | best seam continuity |
+| Same human + different locations | **Parallel** with strong anchors | continuity matters less than identity |
+| Different people / locations | **Parallel** | fastest |
+| Mixed project | **Hybrid** | serial inside continuity-critical blocks, parallel elsewhere |
+
+---
+
+## Execution Commands
+
+### Single Clip (A, B)
 ```bash
 node ${CLAUDE_PLUGIN_ROOT}/skills/renoise-gen/renoise-cli.mjs task generate \
   --prompt "<prompt>" --duration 15 --ratio <ratio> \
   [--materials "ID:ref_image"] [--materials "asset:ID:reference_image"] [--tags "project-tag"]
 ```
 
-**Parallel (most common for C/D/E with visual anchoring):**
+### Parallel Multi-Clip
 ```bash
 # Submit all at once
 for each segment:
   node ${CLAUDE_PLUGIN_ROOT}/skills/renoise-gen/renoise-cli.mjs task create \
     --prompt "<prompt>" --duration 15 --ratio <ratio> \
     --materials "asset:ASSET_ID:reference_image" --tags "<project>,s<N>"
-    # For character refs registered as assets, use "asset:ID:reference_image"
-    # For scene/product refs (no faces), use "MATERIAL_ID:ref_image"
-# Wait for all
+# Wait for completion
 node ${CLAUDE_PLUGIN_ROOT}/skills/renoise-gen/renoise-cli.mjs task wait <id>
 ```
 
-**Serial chain (ref_video for continuous scenes):**
+### Serial Chain (`ref_video`)
 ```bash
-# S1: generate first
+# Generate S1
 node ${CLAUDE_PLUGIN_ROOT}/skills/renoise-gen/renoise-cli.mjs task generate \
   --prompt "<S1>" --duration 15 --ratio <ratio> --tags "<project>,s1"
+
 # Download S1
 curl -s -o "${PROJECT_DIR}/videos/S1.mp4" "<video-url>"
+
 # Upload as ref_video for S2
 node ${CLAUDE_PLUGIN_ROOT}/skills/renoise-gen/renoise-cli.mjs material upload "${PROJECT_DIR}/videos/S1.mp4"
-# S2: uses ref_video
+
+# Generate S2 using S1 continuity
 node ${CLAUDE_PLUGIN_ROOT}/skills/renoise-gen/renoise-cli.mjs task generate \
   --prompt "Continuing from the previous shot: <S2>" --duration 15 --ratio <ratio> \
   --materials "MATERIAL_ID:ref_video" --tags "<project>,s2"
 ```
 
-### Download Results
-
-Video URLs expire after 1 hour. Download immediately:
+### Download Results Immediately
+Video URLs expire after 1 hour:
 ```bash
 curl -s -o "${PROJECT_DIR}/videos/S<N>.mp4" "<video-url>"
 ```
 
 ---
 
-## Stage 6: ASSEMBLE (Multi-Clip Only)
+## Execute Validation Before Assembly
+
+Before assembling multi-clip work, quickly review each clip against the plan.
+
+Check:
+- human identity fidelity
+- environment fidelity
+- product / prop fidelity when relevant
+- action accuracy
+- camera behavior
+- dialogue / lip-sync if relevant
+- seam continuity where the next segment depends on it
+
+If a clip fails because the **plan was incomplete**, go back and fix the plan.
+If a clip fails because the **execution was weak**, adjust prompt / anchor / generation strategy and retry.
+
+Do not rush to assembly just because generation succeeded technically.
+
+---
+
+## Stage 6: ASSEMBLE
 
 ### Concatenate
-
 ```bash
 cd "${PROJECT_DIR}/videos"
 printf "file '%s'\n" S1.mp4 S2.mp4 S3.mp4 ... > concat.txt
 ffmpeg -y -f concat -safe 0 -i concat.txt -c copy "${PROJECT_DIR}/final.mp4"
 ```
 
-### Post-Production
-
-- **Between serial segments**: Should be visually smooth (ref_video continuity)
-- **Between parallel segments**: Add cross-dissolve (0.3-0.5s) to soften visual jumps
-- **BGM overlay**: Strip AI-generated audio, overlay unified BGM:
+### Post-Production Guidance
+- **Serial segments** should already connect smoothly
+- **Parallel segments** often benefit from a 0.3-0.5s cross-dissolve
+- Strip inconsistent AI audio and apply shared BGM when needed
 
 ```bash
 ffmpeg -i final.mp4 -an -c:v copy silent.mp4
 ffmpeg -i silent.mp4 -i bgm.mp3 -c:v copy -c:a aac -shortest final-with-bgm.mp4
 ```
 
-### Post-Delivery
+---
 
-After delivery, update preferences:
+## Post-Delivery Preferences
+
+After delivery, optional preference update:
 ```bash
 cat > ~/.claude/renoise/preferences.json << 'EOF'
 {
@@ -106,3 +174,13 @@ cat > ~/.claude/renoise/preferences.json << 'EOF'
 }
 EOF
 ```
+
+---
+
+## Final Reminder
+
+Execution quality comes from respecting the plan:
+- anchors must stay aligned with prompts
+- quality-critical anchors are not limited to people; environments and props can also be blocking
+- continuity-critical shots need the right generation strategy
+- failed continuity is usually a planning failure first, prompt failure second

--- a/skills/director/references/stage-intake.md
+++ b/skills/director/references/stage-intake.md
@@ -1,88 +1,170 @@
-# Stage 1: INTAKE — Material Collection & Mode Detection
+# Stage 1: INTAKE — PLAN START
 
-Shared across all modes. Goal: collect inputs, analyze materials, check budget, detect mode.
+Shared across all modes. INTAKE is always a **PLAN** stage.
 
-## 1.1 Collect Inputs
+Goal: collect inputs, detect mode, assess materials and budget, and produce a clear project summary that is concrete enough to enter SCRIPT.
 
-- **Mode A/C/E**: User's creative brief, any reference images/videos
-- **Mode B**: Product images + selling points + target audience
-- **Mode D**: Source material (novel text, screenplay, manga pages) + user's vision
+---
 
-## 1.2 Material Check
+## Stage Contract
 
-Ask: "Do you have existing visual materials (reference images, character art, product photos, footage)?"
+### Required Inputs
+- User brief, idea, or source material
+- Any provided images, videos, product shots, scripts, or references
+- User goals: platform, tone, ratio, language, runtime expectations if known
 
-**If yes** — ingest and analyze:
+### Required Outputs
+Before leaving INTAKE, produce:
+- **Mode**: A / B / C / D / E
+- **Project summary**: what the user is trying to make
+- **Material status**: what exists vs. what must be created
+- **Budget snapshot**: current balance and rough cost implication
+- **Open blockers**: anything still unclear enough to affect quality downstream
+
+### Blocking Conditions
+Do **not** move on if any of these are still unclear:
+- what the deliverable actually is
+- which mode fits the request
+- whether materials already exist
+- whether budget supports the current scope
+
+If any blocker remains, ask or summarize the gap explicitly. Do not improvise past it.
+
+---
+
+## 1. Collect Inputs
+
+### Mode A / C / E
+Collect:
+- user's creative brief
+- desired format / ratio if mentioned
+- any reference images, videos, art, or mood samples
+
+### Mode B
+Collect:
+- product images
+- selling points
+- target audience
+- desired tone / creator persona if relevant
+
+### Mode D
+Collect:
+- source material (novel text, screenplay, manga pages, etc.)
+- adaptation intent: faithful, condensed, reimagined, comedic, etc.
+
+---
+
+## 2. Material Check
+
+Ask whether the user has existing visual materials.
+
+**If yes**, ingest and analyze:
 ```bash
 node ${CLAUDE_PLUGIN_ROOT}/skills/renoise-gen/scripts/material-ingest.mjs <paths-or-directory>
 ```
-This uploads files, runs Gemini analysis (tags, descriptions, face detection), and outputs `material-pool.json`.
+This uploads files, runs Gemini analysis, and outputs `material-pool.json`.
 
-**If no** — note empty pool; VISUAL DEV will generate everything from scratch.
+**If no**, record that the material pool is empty and note that later stages must create anchors from scratch.
 
-**For product images (Mode B)** — analyze inline:
+### Product Images (Mode B)
+Analyze inline:
 ```bash
 node ${CLAUDE_PLUGIN_ROOT}/skills/gemini-gen/scripts/gemini.mjs --file <image> --mode product
 ```
 
-**If user provides reference video URLs** — download first:
+### Reference Video URLs
+Download first:
 ```bash
 bash ${CLAUDE_PLUGIN_ROOT}/skills/video-download/scripts/download-video.sh '<URL>'
-# Then ingest the downloaded file:
+```
+Then ingest the downloaded file:
+```bash
 node ${CLAUDE_PLUGIN_ROOT}/skills/renoise-gen/scripts/material-ingest.mjs <downloaded-path>
 ```
 
-## 1.3 Budget Check
+---
 
+## 3. Budget Check
+
+Check available credits:
 ```bash
 node ${CLAUDE_PLUGIN_ROOT}/skills/renoise-gen/renoise-cli.mjs credit me
 ```
 
-Estimate cost: ~300 credits per 15s video clip, ~50 credits per nano-banana-2 image. Inform user of budget vs. plan.
+Use rough planning math:
+- ~300 credits per 15s video clip
+- ~50 credits per `nano-banana-2` image
 
-## 1.4 Auto-detect Mode + Present Summary
+You do not need perfect budget precision here. You do need enough clarity to know whether the current plan is realistic.
 
-"Here's what I understand: [concept]. I'll use **Mode [X]** — [one-line description]."
+---
 
-## Mode Detection Table
+## 4. Detect Mode
 
 | User Signal | Mode |
 |-------------|------|
-| Quick clip, simple concept, single scene, ≤15s | **A** (Quick) |
-| "TikTok", "e-commerce", "product video", "sales video" + product images | **B** (E-commerce) |
-| "short film", "drama", "multi-segment", original story idea, >15s | **C** (Original) |
-| Provides source material (novel, screenplay, manga, storyboard) to adapt | **D** (Adaptation) |
-| "montage", "MV", "music video", "mood piece", non-narrative multi-clip | **E** (Montage) |
+| Quick clip, simple concept, single scene, ≤15s | **A** |
+| Product / TikTok / sales video with product images | **B** |
+| Original short film / drama / multi-segment story | **C** |
+| Adapting source material | **D** |
+| Montage / MV / mood piece | **E** |
 
-## Trust Levels
+Present the result plainly:
+
+> Here's what I understand: [summary]. I'll use **Mode [X]** — [one-line reason].
+
+---
+
+## 5. Trust Levels
+
+Trust level changes brevity, **not requirements**.
 
 | Condition | Level | Behavior |
 |-----------|-------|----------|
-| First-time user | 1 | Full pipeline with all confirmation points |
-| Returning user (has preferences) | 2 | Skip style selection, fewer confirmations |
-| Complete brief provided | 3 | Minimal confirmations, fast-track to generation |
+| First-time user | 1 | Show full planning structure |
+| Returning user | 2 | Be more concise |
+| Very complete brief | 3 | Fast-track, but still produce required outputs |
 
+Optional preference lookup:
 ```bash
 cat ~/.claude/renoise/preferences.json 2>/dev/null
 ```
 
-## Project Initialization (Multi-Clip Modes C/D/E)
+---
 
+## 6. Project Initialization (Modes C / D / E)
+
+For multi-clip projects:
 ```bash
 mkdir -p "${PROJECT_DIR}/storyboard" "${PROJECT_DIR}/videos"
 ```
 
-Store project state in `${PROJECT_DIR}/project.json` for checkpoint recovery:
+Checkpoint state can live in `${PROJECT_DIR}/project.json`:
 ```json
 {
   "mode": "D",
   "title": "...",
   "segments": 6,
   "style_line": "...",
-  "characters": [...],
-  "shots": [
-    {"id": "S1", "status": "completed", "material_id": 42, "asset_id": 27, "task_id": 1234, "video_url": "..."},
-    {"id": "S2", "status": "pending", "material_id": 53}
-  ]
+  "characters": [],
+  "shots": []
 }
 ```
+
+---
+
+## Exit Format
+
+End INTAKE with a concise planning summary, for example:
+
+```md
+## Intake Summary
+Mode: C
+Goal: 4-shot suspense short about a mysterious package
+Materials: 2 hallway refs provided, no character refs yet
+Budget: 1800 credits available, enough for 4 clips + anchor images
+Known gaps: protagonist face anchor, living-room environment anchor
+Next: SCRIPT to lock story beats, segment roles, and anchor needs
+```
+
+Do not leave INTAKE without something equivalent to the above.

--- a/skills/director/references/stage-prompts.md
+++ b/skills/director/references/stage-prompts.md
@@ -1,10 +1,52 @@
-# Stage 4: PROMPTS — Writing Video Generation Prompts
+# Stage 4: PROMPTS — EXECUTE PREP
+
+PROMPTS is an **EXECUTE PREP** stage.
+
+Goal: convert the frozen plan into prompt packages that the model can execute reliably. PROMPTS is not where missing planning decisions should be invented.
 
 > Cross-references:
 > - Model capabilities: `Read ${CLAUDE_PLUGIN_ROOT}/skills/renoise-gen/references/video-capabilities.md`
 > - E-com prompt guide: `Read ${CLAUDE_SKILL_DIR}/references/ecom-prompt-guide.md`
 > - Narrative pacing: `Read ${CLAUDE_SKILL_DIR}/references/narrative-pacing.md`
-> - Continuity: `Read ${CLAUDE_SKILL_DIR}/references/continuity-guide.md`
+> - Continuity / handoff: `Read ${CLAUDE_SKILL_DIR}/references/continuity-guide.md`
+
+---
+
+## Stage Contract
+
+### Required Inputs
+- frozen plan from INTAKE + SCRIPT
+- anchor outputs from VISUAL DEV where applicable
+- style direction
+- segment purpose table
+- continuity strategy table for multi-clip work
+
+### Required Outputs
+Before leaving PROMPTS, produce:
+- final prompt package(s)
+- shot table / rhythm blueprint for multi-clip work
+- prompt-to-anchor alignment
+- continuity handoff language where required
+
+### Blocking Conditions
+Do **not** proceed if:
+- the shot purpose is unclear
+- an important anchor is still undefined
+- continuity strategy is still unresolved
+- a required recurring human, environment, or product / prop anchor is missing
+
+If any of those are true, return to PLAN / VISUAL DEV. Do not patch around them with fancy wording.
+
+---
+
+## Prompt Principles
+
+1. **Prompts implement the plan; they do not replace the plan.**
+2. **Same style line across related segments.**
+3. **Full recurring character description copied verbatim every time.**
+4. **Prompt wording should reflect anchor strategy already chosen.**
+5. **Every quality-critical recurring element should follow the frozen anchor plan, not ad-hoc prompt invention.**
+6. **When continuity matters, use explicit handoff state instead of vague continuation language.**
 
 ---
 
@@ -12,94 +54,164 @@
 
 ### Mode A — One 15s Prompt
 
-```
-[Style line — 1 line, persistent]
+```text
+[Style line]
 
-[Character description — full detail]
+[Character / subject description]
 
-[0-5s] Stage 1 — action beats + camera.
-[Optional dialogue]
+[0-5s] stage 1 — action + camera
+[5-10s] stage 2 — escalation + camera
+[10-15s] stage 3 — payoff + camera
 
-[5-10s] Stage 2 — escalation + camera.
-[Optional dialogue]
-
-[10-15s] Stage 3 — payoff + camera settles.
-[Optional dialogue]
-
+[Dialogue block if needed]
 Sound design: [ambient, SFX].
 No text, subtitles, watermarks, or logos.
 ```
 
 ### Mode B — 1-3 Variant Prompts
 
-Prompt structure: Product anchoring (1 line) + Model description + Timeline narrative (Hook → Showcase → Scene → Close) + Dialogue + BGM + Negative.
+Structure:
+- product anchoring line
+- model / creator description
+- timeline narrative: hook → showcase → use case → close
+- dialogue block
+- sound / vibe
+- negatives
 
-Auto-suggest 3 scene variants. User picks individual or "generate all."
+If generating variants, change scene logic on purpose. Do not create random variants that lack a distinct selling angle.
 
-→ **Confirm (A)** / **Confirm ② (B)**: Present prompt(s). Adjust on feedback. Then generate.
+→ **Confirm (A)** / **Confirm ② (B)**: present prompt package(s), then generate.
 
 ---
 
 ## Multi-Clip Modes (C, D, E)
 
-### Step 1: Shot Table + Rhythm Blueprint
+### Step 1: Validate the Plan Before Writing
+
+Make sure these artifacts exist:
+
+```text
+- Segment Purpose Table
+- Anchor Registry
+- Scene / Environment Anchor Plan
+- Continuity Strategy Table
+- Shot → Anchor Mapping
+```
+
+If any is missing, stop and go back.
+
+### Step 2: Write the Shot Table + Rhythm Blueprint
 
 For each segment:
-```
+
+```text
 S[N]: [scene description] | camera: [movement] | energy: [X→Y→Z]
-      dialogue: "[line]" | transition → S[N+1]: [type]
-      characters: asset:28 (Li Shande), asset:29 (Liu) | scene: material:53 / text-only
+      opening: [opening_state]
+      closing: [closing_state]
+      transition → S[N+1]: [type / serial / parallel]
+      anchors: human [asset:28], environment [material:53], extra [product:66 / storyboard:72 / ref_video]
 ```
 
-**Every character in the shot MUST reference their asset ID from the Character-to-Asset Registry.** If a segment has no character assets listed, it means either (a) no characters appear, or (b) all characters are 1-segment-only with documented text-only justification.
+Present a concise rhythm view:
 
-Present the rhythm blueprint:
-```
+```text
 🎬 [Title] — [N] × 15s
 
-S1 — [Act/Beat label] — Energy: [curve] — [2-word summary]
-  → Transition: [type]
+S1 — [beat label] — [energy] — [summary]
 S2 — ...
 ```
 
-### Step 2: Write All Prompts
+### Step 3: Write All Prompts
 
-Each prompt follows this assembly:
+Each prompt should assemble from the plan in this order:
 
-```
-[Style line — same across ALL segments]
+```text
+[Style line — identical across related segments]
 
-[Character Bible — full, verbatim, every segment the character appears]
+[Optional continuity bridge derived from prior closing_state]
+
+[Character Bible — full, verbatim, for all recurring characters present]
+
+[Anchor guidance if relevant: follow the chosen human anchor / match environment reference image / preserve product or object anchor]
 
 [0-5s] ...
 [5-10s] ...
 [10-15s] ...
 
-[Dialogue in mandatory format if applicable]
+[Dialogue block if needed]
 
 Sound design: [ambient, SFX].
-[Negative prompts from Style Guide].
+[Negative prompts].
 ```
 
-### Key Prompt Rules
+---
 
-1. **Same style line in every prompt** — persistent visual DNA, no mood/color shifts between segments
-2. **Scene-specific mood goes INSIDE time segments** — not in the style line
-3. **Full character description copied verbatim every time** — never abbreviate, even in segment 8
-4. **Mid-film segments end with motion** — only the FINAL segment ends with "frame holds steady"
-5. **Dialogue format**: `Spoken dialogue (say EXACTLY, word-for-word): "[line]"\nTone: [emotion]. Mouth clearly visible when speaking, lip-sync aligned.`
+## Key Prompt Rules
 
-### Material Reference in Prompts
+### 1. Style Consistency
+Use the same style line across all related clips. Mood shifts belong inside the timed action blocks, not in the global style line.
 
-When a shot has an assigned anchor from VISUAL DEV:
+### 2. Character Consistency
+Recurring characters must use the exact same description every time. Never abbreviate because "the model already knows."
 
-| Anchor Type | CLI Flag | In Prompt | When to use |
-|-------------|----------|-----------|-------------|
-| User Asset (face) | `--materials "asset:27:reference_image"` | "Follow the character appearance from the reference image." | **Default for all 2+ segment characters** |
-| Character Library | `--characters "42"` | (automatic, no prompt text needed) | Pre-existing platform characters |
-| Scene ref (no face) | `--materials "53:ref_image"` | "Match the environment from the reference image." | Environment anchoring |
-| Text-only | (no flag) | Full Character Bible description in prompt | **1-segment characters ONLY** |
+### 3. Environment Consistency
+If the plan says a shot uses a scene anchor, the prompt should explicitly respect that anchor. Do not describe a totally different environment than the reference you are sending.
 
-> **⚠️ If you find yourself using text-only for a character that appears in 2+ segments, STOP.** Go back to VISUAL DEV and generate their asset first. Text-only for recurring characters causes visible drift between segments and wastes credits on re-generations.
+### 4. Continuity Discipline
+If a shot depends on the previous shot's ending, start from the planned handoff state, not a vague reset.
 
-→ **Confirm ③**: Present shot table + rhythm. Adjust on feedback. Then generate.
+### 5. Ending Behavior
+Only the final segment should settle fully. Mid-story segments should usually end with motion, tension, or an unfinished handoff when the next segment needs to pick up cleanly.
+
+### 6. Anchor Discipline
+Characters are not the only things that drift. If the plan defines a recurring environment, product, or prop anchor, keep the prompt aligned with that anchor instead of casually reinventing it.
+
+### 7. Dialogue Format
+Use the forced format when needed:
+
+```text
+Spoken dialogue (say EXACTLY, word-for-word): "[line]"
+Tone: [emotion]. Mouth clearly visible when speaking, lip-sync aligned.
+```
+
+---
+
+## Material Reference in Prompts
+
+| Anchor Type | CLI Flag | Prompt Role | When to Use |
+|-------------|----------|-------------|-------------|
+| User Asset | `--materials "asset:27:reference_image"` | locks recurring custom human identity | default for recurring new people |
+| Character Library | `--characters "42"` | locks platform human identity | pre-existing characters |
+| Scene / product / object ref | `--materials "53:ref_image"` | anchors environment, product, or prop appearance | recurring or important non-face elements |
+| Storyboard panel | `--materials "72:ref_image"` | anchors visual DNA / composition | multi-shot consistency |
+| ref_video | `--materials "88:ref_video"` | strongest motion / seam continuity | serial transitions |
+| Text-only | none | fallback only | one-off elements |
+
+> If prompt writing reveals that a recurring human, important environment, or critical product / prop still has no credible anchor, return to VISUAL DEV.
+
+---
+
+## Exit Format
+
+Before leaving PROMPTS, the output should look like a packaged execution spec, not loose text.
+
+Example:
+
+```md
+## Prompt Package
+Style line: ...
+
+## Shot Table
+S1 ...
+S2 ...
+
+## Prompt-to-Anchor Mapping
+S1 → asset:27 + material:53
+S2 → asset:27 + material:61
+S3 → asset:27 + ref_video:88
+
+## Final Prompts
+...
+```
+
+→ **Confirm ③**: present the shot table + prompt package, then generate.

--- a/skills/director/references/stage-script.md
+++ b/skills/director/references/stage-script.md
@@ -1,6 +1,8 @@
-# Stage 2: SCRIPT — Story & Structure Development
+# Stage 2: SCRIPT — PLAN FREEZE CORE
 
-Each mode has a different script structure. Internal coherence checks run silently before presenting to the user.
+SCRIPT is a **PLAN** stage.
+
+Goal: convert the brief into a structure concrete enough to execute without guessing. This is where the project stops being an idea and becomes a plan.
 
 > Cross-references:
 > - Story craft: `Read ${CLAUDE_SKILL_DIR}/references/story-development.md`
@@ -9,29 +11,87 @@ Each mode has a different script structure. Internal coherence checks run silent
 
 ---
 
+## Stage Contract
+
+### Required Inputs
+- INTAKE summary
+- mode selection
+- material status
+- budget snapshot
+
+### Required Outputs
+Before leaving SCRIPT, produce:
+- story structure appropriate to the mode
+- segment-by-segment purpose
+- character usage plan
+- initial anchor needs summary
+- style direction
+- explicit blockers, if any remain
+
+### Blocking Conditions
+Do **not** move to VISUAL DEV or PROMPTS if any of these are missing:
+- what each segment is supposed to do
+- which characters appear where
+- which recurring characters require assets
+- which environments / products / visual anchors matter enough to plan for
+- what kind of continuity matters between segments
+
+The exact format varies by mode, but the planning completeness requirement does not.
+
+---
+
+## Common Planning Outputs for All Modes
+
+No matter the mode, SCRIPT should answer these questions:
+
+1. **What changes from beginning to end?**
+2. **What is each segment for?**
+3. **Who appears in each segment?**
+4. **Which elements need anchoring to avoid drift?**
+5. **Where does continuity matter enough to plan explicitly?**
+
+For multi-clip work, add a lightweight anchor forecast like:
+
+```md
+Anchor Needs Summary
+- Character anchors needed: Maya, Guard
+- Environment anchors needed: hallway, apartment living room
+- Strong continuity required: S2→S3 and S3→S4
+- Parallel-safe transitions: S1→S2 only
+```
+
+---
+
 ## Mode A — Micro-Check
 
-Three lines. If any answer is unclear, ask the user before proceeding.
+Three lines. If any answer is unclear, resolve it before writing prompts.
 
-```
+```text
 Hook  (0-3s):  What expectation am I violating? Why would the viewer NOT swipe?
 Build (3-10s): What CHANGES between the start and end of this section?
 Close (10-15s): What emotion does the viewer walk away with? Is it earned?
 ```
 
-→ **Confirm ①**: Present the micro-check. Proceed to PROMPTS (skip VISUAL DEV).
+Required outputs:
+- micro-check
+- style direction
+- any required anchor note (if product / character / environment reference matters)
+
+→ **Confirm ①**: present the micro-check package, then proceed to PROMPTS.
 
 ---
 
 ## Mode B — Micro-Story
 
-```
-BEFORE:    [viewer's problem / status quo]
+Structure:
+
+```text
+BEFORE:    [viewer problem / status quo]
 TRANSFORM: [how the product changes things]
 AFTER:     [new reality]
 ```
 
-User confirms 5 fields:
+User-facing confirmation fields:
 ```json
 {
   "product_type": "...",
@@ -42,104 +102,183 @@ User confirms 5 fields:
 }
 ```
 
-→ **Confirm ①**: Present product analysis + micro-story. Proceed to PROMPTS (skip VISUAL DEV for single-clip; do product analysis for multi-scene).
+Also decide:
+- how many variants to generate
+- whether the product image alone is enough anchor
+- whether model consistency matters across variants
+
+→ **Confirm ①**: product analysis + micro-story + anchor note.
 
 ---
 
 ## Mode C — Logline + Treatment (Original)
 
-**Step 1: Logline** — one sentence:
-```
+### Step 1: Logline
+```text
 When [INCITING INCIDENT], a [CHARACTER] must [GOAL], but [OBSTACLE] threatens [STAKES].
 ```
 
-**Step 2: Treatment** — prose narrative, 2-3 sentences per scene. Describe what the viewer SEES and FEELS. Embed dialogue naturally.
+### Step 2: Treatment
+Write 2-3 sentences per segment. Describe what the viewer sees and feels. Dialogue should emerge from the scene, not explain it from outside.
 
-**Step 3 (internal, not shown to user)**: Run coherence self-check:
-- Every scene transition is THEREFORE or BUT (no AND THEN)
-- No two adjacent scenes target the same viewer emotion
-- Every character action has explicit motivation
-- Every dialogue line serves a purpose (reveal / conflict / emotion / character)
+### Step 3: Internal Coherence Check
+Run the checklist silently:
+- every scene transition is THEREFORE or BUT
+- adjacent scenes do not target the same emotion
+- character actions are motivated
+- dialogue lines serve a purpose
 
-If any check fails, fix the treatment silently before presenting.
+Fix silently before presenting.
 
-**Step 4: Character Asset Plan (MANDATORY).** For every character in the treatment, produce this table:
+### Step 4: Character Asset Plan (MANDATORY)
+For every character:
 
-```
+```text
 | Character | Segments | Asset Strategy | Justification |
 |-----------|----------|----------------|---------------|
 | [name]    | S1,S3,S5 | ✅ Generate Asset | Appears in 3 segments |
-| [name]    | S3       | ❌ Text-only     | Single scene only |
+| [name]    | S3       | ❌ Text-only | Single segment only |
 ```
 
-**Rule: Any character appearing in 2+ segments MUST have strategy "✅ Generate Asset".** Text-only is permitted ONLY for characters in exactly 1 segment.
+Rule: any character appearing in **2+ segments** must be `✅ Generate Asset` or mapped to an existing Character Library entry.
 
-**Step 5: Style direction** — propose 1-2 style options based on content.
+### Step 5: Segment Purpose Table (MANDATORY)
 
-Output to user: **logline + treatment + character asset plan + style recommendation** (one concise package).
+```text
+| Segment | Story Function | Emotion | Key Location | Continuity Importance |
+|---------|----------------|---------|--------------|-----------------------|
+| S1      | setup          | curiosity | hallway     | low |
+| S2      | discovery      | wonder    | living room | high |
+```
 
-→ **Confirm ①**: User approves or adjusts the story + style + character plan.
+### Step 6: Style Direction
+Propose 1-2 style options.
+
+### Step 7: Anchor Needs Summary
+List the important anchors and continuity links before VISUAL DEV.
+
+Output to user:
+- logline
+- treatment
+- character asset plan
+- segment purpose table
+- anchor needs summary
+- style recommendation
+
+→ **Confirm ①**: approve story + style + asset logic.
 
 ---
 
 ## Mode D — Select + Condense (Adaptation)
 
-The source material already contains the story. The task is to **select** the best moments and **condense** them for video.
+### Step 1: Parse Source Material
+Extract:
+- scene inventory
+- character roster
+- emotional peaks
+- visually strong moments
 
-**Step 1: Parse source material.** Extract:
-- Scene inventory (number + one-line summary each)
-- Character roster (name + appearance + key traits)
-- Emotional peaks / most visual moments
+### Step 2: Recommend a Condensed Plan
+Include:
+- suggested segment count
+- selected scenes + rationale
+- emotional arc
+- what is cut and why
 
-**Step 2: Recommend a plan.**
-- Suggested segment count (based on budget + story density)
-- Selected scenes + rationale for each
-- Emotional arc formed by the selected scenes
-- What's cut and why
+### Step 3: Write Condensed Treatment
+Only for the selected scenes.
 
-**Step 3: Write condensed treatment** for selected scenes only (2-3 sentences each).
+### Step 4: Character Asset Plan (MANDATORY)
+Use the same table structure as Mode C.
 
-**Step 4: Character Asset Plan (MANDATORY).** For every character extracted in Step 1, produce this table:
+### Step 5: Segment Purpose Table (MANDATORY)
+Use the same structure as Mode C.
 
-```
-| Character | Segments | Asset Strategy | Justification |
-|-----------|----------|----------------|---------------|
-| [name]    | S1,S3,S5 | ✅ Generate Asset | Appears in 3 segments |
-| [name]    | S3,S5    | ✅ Generate Asset | Appears in 2 segments |
-| [name]    | S4       | ❌ Text-only     | Single scene, minor role |
-```
+### Step 6: Anchor Needs Summary
+Identify:
+- recurring characters needing assets
+- key environments needing anchors
+- segments that need tight continuity
+- segments safe for looser transitions
 
-**Rule: Any character appearing in 2+ segments MUST have strategy "✅ Generate Asset".** Text-only is permitted ONLY for characters in exactly 1 segment. This table feeds directly into VISUAL DEV Step 3a — every "✅ Generate Asset" row becomes a character sheet to generate.
+### Step 7: Internal Coherence Check
+Run silently.
 
-Include the asset cost in the budget estimate: ~12 credits per character image + ~0 for registration.
+### Step 8: Style Direction
+Based on period / tone / genre of the source.
 
-**Step 5 (internal)**: Coherence self-check on the condensed version.
+Output to user:
+- scene selection table
+- emotional arc
+- treatment
+- character asset plan
+- segment purpose table
+- anchor needs summary
+- style direction
 
-**Step 6: Style direction** — propose style based on source material's tone/period/genre.
-
-Output to user: **scene selection table + emotional arc + treatment + character asset plan + style**.
-
-→ **Confirm ①**: User approves or adjusts scene selection + treatment + character plan.
+→ **Confirm ①**: approve selection + treatment + asset logic.
 
 ---
 
 ## Mode E — Beat Sheet (Montage / MV)
 
-No narrative causation required. Structure is driven by **mood + rhythm**.
+### Step 1: Core Emotion
+One word: nostalgia, euphoria, melancholy, adrenaline, etc.
 
-**Step 1: Core emotion** — one word (nostalgia, euphoria, melancholy, adrenaline...).
-
-**Step 2: Beat sheet** — per segment:
-```
+### Step 2: Beat Sheet
+```text
 S1: [visual keyword] — mood: [X] — energy: [N/10]
 S2: [visual keyword] — mood: [X] — energy: [N/10]
 ...
 ```
 
-**Step 3: Rhythm reference** — BPM, genre, reference track/mood.
+### Step 3: Rhythm Reference
+BPM, genre, reference track / feel.
 
-**Step 4: Style direction.**
+### Step 4: Segment Purpose Table
+Even without plot, define what each segment contributes.
 
-Output to user: **core emotion + beat sheet + energy curve + style**.
+### Step 5: Anchor Needs Summary
+Which environments, recurring subjects, or visual motifs need anchoring?
+Which transitions need strong continuity, if any?
 
-→ **Confirm ①**: User approves or adjusts the beat sheet.
+### Step 6: Style Direction
+
+Output to user:
+- core emotion
+- beat sheet
+- rhythm reference
+- segment purpose table
+- anchor needs summary
+- style direction
+
+→ **Confirm ①**: approve the beat sheet package.
+
+---
+
+## Exit Format
+
+Before leaving SCRIPT, the user-facing package should look like a plan, not a loose brainstorm. Example:
+
+```md
+## Story Plan
+Logline: ...
+Treatment: ...
+
+## Segment Purpose
+S1: setup
+S2: discovery
+S3: escalation
+S4: resolution
+
+## Character Asset Plan
+...
+
+## Anchor Needs Summary
+...
+
+## Style Direction
+...
+```
+
+If the plan is too vague to survive execution without guesswork, stay in SCRIPT.

--- a/skills/director/references/visual-development.md
+++ b/skills/director/references/visual-development.md
@@ -1,327 +1,296 @@
 # Visual Development Guide
 
-The pipeline for transforming text descriptions into visual assets that anchor video generation. This stage bridges SCRIPT → PROMPTS by creating character design sheets, scene references, and storyboard grids — all uploaded as materials and referenced in every video prompt.
+VISUAL DEV bridges late **PLAN** and early **EXECUTE**.
 
-## Why Visual Dev Matters
+Goal: turn abstract planning decisions into concrete anchors the model can actually follow. This stage exists to prevent drift.
 
-| Approach | Character Consistency | Setup Time | Credits |
-|----------|----------------------|------------|---------|
-| Text-only (no visual dev) | Low — model drifts per generation | 0 min | 0 |
-| Storyboard grid as ref_image | Medium-High — shared visual DNA | ~15 min | ~50-150 |
-| Char sheets + scene refs + storyboard | Highest — layered anchoring | ~30 min | ~150-400 |
+In practical terms, VISUAL DEV answers:
+- What will anchor recurring people?
+- What will anchor important environments, products, or props?
+- What will each shot reference?
+- Where does clip-to-clip continuity need stronger support?
 
-**Rule**: For any project with 3+ segments and recurring characters, ALWAYS do visual dev. The time investment pays for itself in fewer re-generations.
+---
 
-## Sub-Pipeline Overview
+## Stage Contract
 
-```
-┌─────────────┐   ┌──────────────┐   ┌─────────────────┐   ┌───────────────┐   ┌───────────────┐
-│ 1. MATCH    │──▶│ 2. GAP       │──▶│ 3. GENERATE     │──▶│ 4. REGISTER   │──▶│ 5. MAP        │
-│ existing    │   │ analysis     │   │ missing assets   │   │ face assets   │   │ shot→material │
-│ materials   │   │ + characters │   │ (images)         │   │ as Ark assets │   │ + assets      │
-└─────────────┘   └──────────────┘   └─────────────────┘   └───────────────┘   └───────────────┘
-```
+### Required Inputs
+- approved SCRIPT package
+- segment purpose table
+- character asset plan
+- anchor needs summary
+- style direction
 
-> **Critical**: Images containing human faces **must** go through asset registration before use in video generation. Three options (strongest → weakest):
-> 1. **User Asset** — generate character image → upload → `asset register` → use as `asset:ID:reference_image` (bypass privacy detection, ~1 min setup)
-> 2. **Character Library** — pre-existing platform characters → `--characters "ID"` (bypass privacy detection, zero setup if character exists)
-> 3. **Text-only** — full Character Bible description in prompt (no images, no privacy issues, lowest consistency)
+### Required Outputs
+Before leaving VISUAL DEV, produce:
+- **Anchor Registry**
+- **Scene / Environment Anchor Plan**
+- **Shot → Anchor Mapping**
+- **Continuity Strategy Table**
+- any generated / registered assets and their IDs
+
+### Blocking Conditions
+Do **not** move to PROMPTS if any of these are missing for quality-critical shots:
+- recurring human anchor
+- important recurring environment anchor
+- important recurring product / object anchor when the shot depends on it
+- shot-level anchor assignment
+- continuity strategy for tight handoffs
+
+If a key anchor is missing, either create it here or explicitly downgrade the plan with user awareness. Do not silently continue.
+
+---
+
+## Why This Stage Matters
+
+| Approach | Consistency | Setup Time | Cost | Best Use |
+|----------|-------------|------------|------|----------|
+| Text-only | Low | 0 | 0 | Simple one-off shots |
+| Storyboard-only | Medium | Low-Med | Low-Med | Palette / composition anchoring |
+| Human + scene + storyboard anchors | High | Med | Med | Multi-clip work with continuity needs |
+
+**Rule of thumb:** for multi-clip work, recurring people, environments, and important props should have anchors planned on purpose, not by accident.
 
 ---
 
 ## Step 1: Match Existing Materials
 
-If the user provided materials during INTAKE (uploaded via `material-ingest.mjs`), score them against project needs.
+If INTAKE produced a material pool, score it against project needs:
 
 ```bash
 node ${CLAUDE_PLUGIN_ROOT}/skills/renoise-gen/scripts/match-materials.mjs \
   --pool material-pool.json --shots project.json
 ```
 
-This outputs a mapping with confidence scores:
-```
-character "protagonist" → material #5  (score: 0.91) ✅
-character "sidekick"    → no match                    ❌
-scene "office"          → material #23 (score: 0.78)  ✅
-scene "tavern"          → no match                    ❌
-shot S1               → material #42 (score: 0.85)  ✅
-shot S3               → no match                    ❌
-```
+This helps separate:
+- what is already usable
+- what can be reused
+- what still needs creation
 
-**If no material pool exists**: Skip to Step 2 with everything marked as ❌.
+If no material pool exists, mark those needs as unresolved and continue to gap analysis.
 
 ---
 
 ## Step 2: Gap Analysis
 
-### Step 2a: Check Existing Face-Safe References
+### 2a. Check Existing Face-Safe Options
 
-Before generating any character design sheets, check what's already available:
+Before generating new character art, inspect existing options:
 
 ```bash
-# Check Character Library (pre-existing platform characters)
 node ${CLAUDE_PLUGIN_ROOT}/skills/renoise-gen/renoise-cli.mjs character list
-node ${CLAUDE_PLUGIN_ROOT}/skills/renoise-gen/renoise-cli.mjs character list --search "warrior"
-
-# Check existing User Assets (previously registered)
 node ${CLAUDE_PLUGIN_ROOT}/skills/renoise-gen/renoise-cli.mjs asset list --status active
 ```
 
-If suitable characters/assets are found, note their IDs and skip generating those characters.
+If suitable characters or assets already exist, reuse them.
 
-If none exist, the plan is: **generate character image → upload → register as User Asset → use `asset:ID:reference_image`**. This is detailed in Step 3a and Step 4 below.
+### 2b. Identify Missing Anchors
 
-### Step 2b: Compare Materials Against Needs
+Use a planning table like this:
 
-Compare matched materials against full project needs:
+```text
+| Need | Reuse? | New Asset Needed? | Anchor Type |
+|------|--------|-------------------|-------------|
+| Maya (S1-S4) | no | yes | User Asset |
+| Hallway (S1) | yes | no | scene ref_image |
+| Living room (S2-S4) | no | yes | scene ref_image + storyboard |
+| Pocket watch | maybe | maybe | object/product ref |
+```
 
-| Need | Matched? | Action |
-|------|----------|--------|
-| Character: [protagonist] (8 segments) | ✅ existing User Asset #27 | Use `--materials "asset:27:reference_image"` |
-| Character: [protagonist] (8 segments) | ✅ in Character Library #42 | Use `--characters "42"` |
-| Character: [supporting] (2+ segments) | ❌ no asset or library entry | **MUST Generate → upload → asset register** |
-| Character: [cameo] (1 segment only) | ❌ no asset | Text-only acceptable |
-| Scene: [location A] | ✅ material (no faces) | Use as `--materials "ID:ref_image"` |
-| Scene: [location B] | ❌ | Generate scene ref (no faces, optional) |
-| Storyboard grid | ❌ | Generate (environment-only panels, recommended) |
+### Anchor Priority
 
-**Priority for face references**: User Asset (`asset:ID:reference_image`) = Character Library (`--characters "ID"`) > Text-only.
-**Priority for non-face references**: Material `ref_image` > Storyboard grid panel > Text-only.
+**Faces / characters**
+1. User Asset (`asset:ID:reference_image`)
+2. Character Library (`--characters "ID"`)
+3. Text-only fallback
 
-**Characters appearing in 2+ segments MUST have asset registration — this is not optional.** The cost is negligible (~12 credits per image) vs. the visual consistency benefit. Scene refs help but are less critical if the storyboard grid already depicts those environments.
+**Non-face anchors**
+1. scene / product `ref_image`
+2. storyboard panel
+3. text-only
 
 ---
 
-## Step 3: Generate Missing Assets
+## Step 3: Build the Anchor Plan First
 
-All assets generated with `nano-banana-2` (image model).
+Before generating anything, write the plan explicitly.
 
-### 3a. Character Design Sheets
+### 3a. Anchor Registry
 
-One sheet per main character. Shows multiple angles and expressions in a single image, ensuring the model generates a consistent face/body.
-
-**Prompt template:**
+```text
+| Anchor | Type | Segments | Anchor Strategy | Asset ID / Source | Notes |
+|--------|------|----------|-----------------|-------------------|-------|
+| Maya | recurring human | S1-S4 | User Asset | pending | recurring lead |
+| Courier | one-shot human | S1 | Text-only | — | cameo only |
+| Hallway | environment | S1 | existing scene ref | material:53 | already provided |
+| Pocket watch | object | S2-S4 | product/object ref | pending | recurring hero prop |
 ```
+
+### 3b. Scene / Environment Anchor Plan
+
+```text
+| Environment | Segments | Anchor Strategy | Material ID | Notes |
+|-------------|----------|-----------------|-------------|-------|
+| Hallway | S1 | existing scene ref | 53 | already provided |
+| Living room | S2-S4 | generate scene ref | pending | recurring key location |
+| Magical living room state | S3-S4 | storyboard + prompt lighting variation | pending | derived from living room |
+```
+
+### 3c. Continuity Strategy Table
+
+```text
+| Transition | Continuity Need | Strategy | Why |
+|------------|------------------|----------|-----|
+| S1→S2 | medium | parallel + continuity text | location change |
+| S2→S3 | high | serial / ref_video preferred | same room, continuous action |
+| S3→S4 | high | serial preferred | same room, aftermath |
+```
+
+**This table is mandatory for multi-clip work.** It keeps the team from pretending all transitions are equal.
+
+---
+
+## Step 4: Generate Missing Assets
+
+All image assets use `nano-banana-2`.
+
+### 4a. Character Design Sheets
+
+Use when a character needs a reusable face anchor.
+
+Prompt template:
+```text
 Character design sheet for [CHARACTER NAME].
 
-[FULL CHARACTER DESCRIPTION — verbatim from Character Bible, including:
-  age, ethnicity, face details, hair, skin tone, body type,
-  wardrobe (texture + cut + color for each garment),
-  signature details (jewelry, accessories, props)]
+[FULL CHARACTER DESCRIPTION from Character Bible]
 
 Layout: 2 rows × 3 columns on clean white background.
-Row 1: front view (neutral expression), 3/4 view (neutral), side profile (neutral).
-Row 2: front view ([emotion A] expression), front view ([emotion B] expression), full body pose.
+Row 1: front, 3/4, side profile.
+Row 2: two expressions + full body pose.
 
-[STYLE LINE from project — e.g. "Cinematic period drama, warm earth tones, film grain."]
-Concept art style, clean lines, consistent appearance across all panels.
+[STYLE LINE]
+Concept art style, consistent appearance across all panels.
 No text labels. No background elements.
 ```
 
-**CLI:**
+CLI:
 ```bash
 node ${CLAUDE_PLUGIN_ROOT}/skills/renoise-gen/renoise-cli.mjs task generate \
   --model nano-banana-2 --resolution 2k --ratio 16:9 \
   --prompt "<character sheet prompt>" --tags "<project>,char-<name>"
 ```
 
-**Upload + Register as Asset (for face-safe use):**
-```bash
-# Download the generated image
-curl -s -o character-sheet.png "<image_url>"
+### 4b. Scene Reference Images
 
-# Upload as material
-node ${CLAUDE_PLUGIN_ROOT}/skills/renoise-gen/renoise-cli.mjs material upload character-sheet.png
-# → Returns material ID (e.g. #101)
+Use for recurring or important environments.
 
-# Register as Ark asset (one-step: create + wait ~30-60s)
-node ${CLAUDE_PLUGIN_ROOT}/skills/renoise-gen/renoise-cli.mjs asset register 101 --name "Maya - Character Reference"
-# → Returns asset ID (e.g. #27) when active
-# Use in video: --materials "asset:27:reference_image"
-```
-
-> **Why asset register?** Character design sheets contain human faces. Using them directly as `ref_image` via material ID triggers privacy detection. Registering as an Ark asset creates an `asset://` URI that bypasses this entirely.
-
-### 3b. Scene Reference Images
-
-One image per key location. No characters — environment only.
-
-**Prompt template:**
-```
-[LOCATION DESCRIPTION — architecture, materials, objects, scale]
-[TIME OF DAY + LIGHTING — e.g. "Late afternoon, golden hour side-lighting through tall windows"]
+Prompt template:
+```text
+[LOCATION DESCRIPTION]
+[TIME OF DAY + LIGHTING]
 [STYLE LINE]
-Cinematic composition, wide establishing shot. No people, environment only.
-No text, watermarks, or logos.
+Cinematic wide establishing shot. Environment only.
+No people, text, logos, or watermarks.
 ```
 
-**CLI:**
+CLI:
 ```bash
 node ${CLAUDE_PLUGIN_ROOT}/skills/renoise-gen/renoise-cli.mjs task generate \
   --model nano-banana-2 --resolution 2k --ratio 16:9 \
   --prompt "<scene ref prompt>" --tags "<project>,scene-<name>"
 ```
 
-Upload and record material ID.
+### 4c. Storyboard Grid
 
-### 3c. Storyboard Grid
+Use when you want shared visual DNA across many shots.
 
-A single image containing key frames from ALL segments, arranged in a grid. Because the AI renders all panels in one context, characters share consistent face structure, proportions, and styling across panels.
-
-**Prompt template:**
-```
-Storyboard grid for "[PROJECT TITLE]", [N] panels arranged in [R] rows × [C] columns.
+Prompt template:
+```text
+Storyboard grid for "[PROJECT TITLE]", [N] panels.
 
 [STYLE LINE]
+[FULL CHARACTER DESCRIPTIONS as needed]
 
-[For each character in the project, full Character Bible description — verbatim]
-
-Panel 1 (S1 — [scene label]): [Key visual moment, 1 sentence. Include character action + environment + lighting mood]
-Panel 2 (S2 — [scene label]): [Key visual moment]
-Panel 3 (S3 — [scene label]): [Key visual moment]
+Panel 1 (S1): ...
+Panel 2 (S2): ...
 ...
 
-Consistent character appearance across all panels. Each panel is a distinct scene with its own lighting and environment.
-Cinematic composition per panel. No text labels.
+Consistent appearance across panels. No text labels.
 ```
 
-**CLI:**
+CLI:
 ```bash
 node ${CLAUDE_PLUGIN_ROOT}/skills/renoise-gen/renoise-cli.mjs task generate \
   --model nano-banana-2 --resolution 2k --ratio 16:9 \
   --prompt "<storyboard grid prompt>" --tags "<project>,storyboard"
 ```
 
-**Split grid into individual panels** (if needed for per-segment ref_image):
+Optional split:
 ```bash
-# Using ImageMagick or ffmpeg
-# For a 2×3 grid:
 convert storyboard.png -crop 3x2@ +repage +adjoin panel_%d.png
 ```
 
-Upload each panel:
-```bash
-for f in panel_*.png; do
-  node ${CLAUDE_PLUGIN_ROOT}/skills/renoise-gen/renoise-cli.mjs material upload "$f"
-done
-```
-
-### Generation Order
-
-Generate assets in parallel when possible:
-- Character sheets and scene refs have no dependencies → generate simultaneously
-- Storyboard grid depends on knowing the character descriptions and scenes → generate after reviewing char sheets (to ensure consistency)
-
-Alternatively, if budget is tight, skip character sheets and scene refs — generate ONLY the storyboard grid. It provides the most consistency-per-credit.
-
 ---
 
-## Step 4: Register Face-Containing Assets
+## Step 5: Register Face Assets
 
-**NEW STEP** — Any generated image containing human faces must be registered as an Ark asset before use.
+Any face-containing image intended for video reference must be registered:
 
 ```bash
-# For each character design sheet generated in Step 3a:
+node ${CLAUDE_PLUGIN_ROOT}/skills/renoise-gen/renoise-cli.mjs material upload character-sheet.png
 node ${CLAUDE_PLUGIN_ROOT}/skills/renoise-gen/renoise-cli.mjs asset register <material_id> --name "<Character Name>"
-# Waits ~30-60s, returns asset ID when active
 ```
 
-Scene refs and storyboard panels (no faces) do NOT need registration — use them directly as `--materials "ID:ref_image"`.
+Use the resulting asset ID in video generation:
+```text
+--materials "asset:27:reference_image"
+```
+
+Never rely on raw `ref_image` for close-up faces.
 
 ---
 
-## Step 5: Build Final Mapping
+## Step 6: Build Final Shot Mapping
 
-Create a complete shot → anchor mapping:
+This is the real output of VISUAL DEV.
 
-```
-Shot    Anchor Type              Reference              CLI Flag
-─────   ──────────────────────   ────────────────────   ───────────────────────────────────
-S1      User Asset (face)        asset #27 (Maya)       --materials "asset:27:reference_image"
-S2      scene ref (no face)      material #53           --materials "53:ref_image"
-S3      Character Library        char #42               --characters "42"
-S4      storyboard panel         material #54           --materials "54:ref_image"
-S5      text-only                —                      (Character Bible in prompt)
-
-Face Reference Registry:
-  Maya (protagonist)   asset #27   (used in S1, S3, S5)
-  Wei (supporting)     asset #28   (used in S3)
-  Elder (cameo)        char #42    (Character Library, used in S3)
+```text
+| Shot | Human Anchor | Environment Anchor | Extra Anchor | Continuity Strategy |
+|------|--------------|--------------------|--------------|---------------------|
+| S1 | asset:27 | material:53 | object:watch | establish |
+| S2 | asset:27 | material:61 | storyboard:72 | parallel |
+| S3 | asset:27 | material:61 | ref_video from S2 | serial |
+| S4 | asset:27 | material:61 | ref_video from S3 | serial |
 ```
 
-**Anchor selection decision tree:**
-
-1. **Has face + generated character image** → `--materials "asset:ID:reference_image"` (User Asset, strongest for new characters)
-2. **Has face + exists in Character Library** → `--characters "ID"` (strongest for pre-existing characters)
-3. **No face (scene, product, environment)** → `--materials "ID:ref_image"` (safe, no registration needed)
-4. **No suitable materials** → text-only with full Character Bible (always works)
-
-> **Rule**: Never use raw `ref_image` (material ID) for images containing human faces. Either register as User Asset or use Character Library. `ref_image` is only for face-free content.
-
-**⚠️ Privacy & Face Detection**:
-- **Character design sheets** generated by `nano-banana-2` contain AI-generated faces that WILL trigger privacy detection if used as raw `ref_image`. **Always register them as User Assets first** (`asset register`).
-- **Storyboard grid panels** with small figures usually pass as `ref_image`, but close-up face panels may be blocked.
-- **If any `ref_image` is blocked**:
-  1. **Best**: Register the image as a User Asset → `asset register <material_id>` → use `asset:ID:reference_image`
-  2. **Alternative**: Use Character Library → `--characters "ID"` (if the character exists there)
-  3. **Fallback**: Drop the image entirely, use text-only with full Character Bible
-- **Real photographs of human faces** — must go through User Asset registration or Character Library. Never use as raw `ref_image`.
+This mapping is what PROMPTS must follow.
 
 ---
 
-## Visual Dev by Mode
+## Checklist Before Proceeding
 
-| Mode | Character Sheets | Scene Refs | Storyboard Grid |
-|------|-----------------|------------|-----------------|
-| A (Quick) | Skip | Skip | Skip |
-| B (E-commerce) | Skip (text description) | Skip (product photo is the ref) | Skip |
-| C (Original) | ✅ All main characters | ✅ Key locations | ✅ Always |
-| D (Adaptation) | ✅ All main characters | ✅ Key locations | ✅ Always |
-| E (Montage) | Optional (if recurring character) | ✅ Key environments | ✅ Always (mood anchoring) |
+### Blocking
+- [ ] Every recurring human has a real anchor strategy
+- [ ] All face anchors are registered or mapped to Character Library
+- [ ] Important recurring environments have anchors or an explicit fallback decision
+- [ ] Important recurring products / props have anchors or an explicit fallback decision when the shot depends on them
+- [ ] Multi-clip transitions have a continuity strategy
+- [ ] Shot → Anchor Mapping is complete
 
----
+### Required Output Tables
+- [ ] Anchor Registry
+- [ ] Scene / Environment Anchor Plan
+- [ ] Continuity Strategy Table
+- [ ] Shot → Anchor Mapping
 
-## Efficiency Tips
-
-1. **Character sheets are NOT optional for 2+ segment characters.** Every character appearing in 2+ segments MUST have a registered User Asset. At ~12 credits per image + ~1 min registration, this is negligible compared to the 300 credits per video segment. Skipping character assets to "save budget" is a false economy — inconsistent characters require expensive re-generations.
-
-2. **Scene refs and storyboard grids CAN be skipped** if budget is tight. These provide environmental consistency but are less critical than character assets. Priority order: character assets (mandatory) > storyboard grid (recommended) > scene refs (nice-to-have).
-
-3. **Quality-maximizing path**: Generate character sheets first, review them, then reference those designs when writing the storyboard grid prompt. The grid will be more consistent because you've already locked the character look.
-
-4. **Parallel generation**: Character sheets and scene refs are independent — generate them all simultaneously (~8 min total regardless of count). Then generate the storyboard grid.
-
-5. **Re-use across episodes**: Save material IDs. For episodic content (same characters, new story), reuse character sheets and regenerate only new scene refs + storyboard grid.
+If these four artifacts do not exist, VISUAL DEV is not done.
 
 ---
 
-## Checklist Before Proceeding to PROMPTS
+## Efficiency Notes
 
-**Character Assets (BLOCKING — cannot proceed if any fail):**
-- [ ] Character Library and existing User Assets checked
-- [ ] Every character appearing in **2+ segments** has a registered User Asset (asset ID) or Character Library entry — **text-only is NOT acceptable for 2+ segment characters** unless image generation failed after retry
-- [ ] All face-containing character images are registered as User Assets (`asset register`) and status is `active`
-- [ ] Characters in exactly 1 segment may use text-only (document which ones and why)
-
-**Character-to-Asset Registry (MANDATORY — output this table before proceeding):**
-```
-| Character | Segments | Asset ID | Strategy |
-|-----------|----------|----------|----------|
-| [name]    | S1-S8    | asset:28 | User Asset ✅ |
-| [name]    | S3,S5    | asset:29 | User Asset ✅ |
-| [name]    | S7,S8    | asset:30 | User Asset ✅ |
-| [name]    | S4       | —        | Text-only (1 segment) |
-```
-
-**Scene & Environment (recommended, not blocking):**
-- [ ] Every key location has either a matched material or a generated scene ref (face-free)
-- [ ] Storyboard grid generated (if applicable) with environment-focused panels
-- [ ] All non-face assets are uploaded and have material IDs
-
-**Shot Mapping:**
-- [ ] Shot → anchor mapping is complete, using the correct CLI flag format:
-  - Face images: `--materials "asset:ID:reference_image"` or `--characters "ID"`
-  - Non-face images: `--materials "ID:ref_image"`
-  - No anchor: text-only with full Character Bible (1-segment characters only)
-- [ ] No raw `ref_image` contains close-up human faces
-- [ ] User has reviewed and approved the visual assets (Confirm ②)
+- Human identity anchors are usually the highest-value investment
+- Scene anchors become critical when the same location appears multiple times
+- Product / prop anchors matter when the object itself must stay recognizably consistent
+- Storyboard grids are strong for overall visual DNA, but weaker than face-safe assets for identity
+- If a transition must match tightly at the seam, choose serial / `ref_video` early instead of hoping prompt wording will solve it later

--- a/skills/renoise-gen/SKILL.md
+++ b/skills/renoise-gen/SKILL.md
@@ -4,7 +4,7 @@ description: Generate AI videos and images via Renoise platform. Create tasks, u
 allowed-tools: Bash, Read, Write, Glob
 metadata:
   author: renoise
-  version: 0.2.0
+  version: 0.3.0
   category: video-production
   tags: [general, video-generation, image-generation, product-sheet, scene-background, material-pool]
 ---
@@ -17,7 +17,7 @@ Generate AI videos, images, product design sheets, and scene backgrounds through
 
 ## Choose Your Workflow First
 
-Before generating anything, identify your project type. Different projects require different preparation steps. **Skipping preparation for multi-scene projects will result in inconsistent characters across scenes.**
+Before generating anything, identify your project type. Different projects require different preparation steps. **Skipping preparation for multi-scene projects will result in inconsistent characters, scenes, and objects across shots.**
 
 | Project Type | Examples | Workflow |
 |---|---|---|
@@ -28,9 +28,34 @@ Before generating anything, identify your project type. Different projects requi
 
 ---
 
+## Anchor Model
+
+Treat every reference as one of these anchor types:
+
+| Anchor Type | What it is | Best For |
+|---|---|---|
+| **Asset** | Reusable, stable, face-safe anchor | Recurring people and long-lived identity anchors |
+| **Character Library** | Platform-managed face-safe human anchor | Pre-existing platform characters |
+| **Material** | Raw uploaded media | Products, environments, motion refs, temporary inputs |
+| **Storyboard / panel** | Shared visual DNA anchor | Palette, composition, scene family resemblance |
+| **Text-only** | Prompt-only fallback | One-off elements or last resort |
+
+### Anchor Hierarchy
+
+Prefer anchors in this order when consistency matters:
+1. **User Asset / Asset**
+2. **Character Library**
+3. **Scene / product / object material**
+4. **Storyboard panel / grid**
+5. **Text-only**
+
+**Do not treat raw materials as interchangeable with assets.** Materials are inputs; assets are durable anchors.
+
+---
+
 ## Multi-Scene Production Workflow
 
-**Use this workflow whenever your project has recurring characters across 2+ scenes.** This is the most common workflow for drama, short films, and narrative content.
+**Use this workflow whenever your project has recurring people, environments, or key objects across 2+ scenes.** This is the most common workflow for drama, short films, and narrative content.
 
 ### Step 1: Check Balance
 
@@ -41,9 +66,19 @@ node ${CLAUDE_SKILL_DIR}/renoise-cli.mjs credit me
 node ${CLAUDE_SKILL_DIR}/renoise-cli.mjs credit estimate --duration 15
 ```
 
-### Step 2: Generate Character Reference Sheets
+### Step 2: Build an Anchor Package
 
-For each recurring character, generate a reference sheet with `nano-banana-2`. This anchors their appearance across all scenes.
+Before generating shots, decide which recurring elements need durable anchors.
+
+Minimum anchor package for multi-scene work:
+- recurring people → **User Asset** or **Character Library**
+- recurring environments → scene or storyboard anchor
+- recurring products / props → product or object anchor where needed
+- continuity-critical transitions → `ref_video` plan or explicit handoff state
+
+### Step 3: Generate Character Reference Sheets
+
+For each recurring human character that does not already exist as a Character Library entry, generate a reference sheet with `nano-banana-2`. This anchors their appearance across all scenes.
 
 ```bash
 # Example: generate a character reference for a Tang Dynasty official
@@ -54,7 +89,7 @@ node ${CLAUDE_SKILL_DIR}/renoise-cli.mjs task generate \
 
 **Do this for every character that appears in 2+ scenes.** Minor one-scene characters can be described in text only.
 
-### Step 3: Download, Upload, and Register as Assets
+### Step 4: Download, Upload, and Register as Assets
 
 This makes them privacy-safe and reusable across all video generations.
 
@@ -71,7 +106,7 @@ node ${CLAUDE_SKILL_DIR}/renoise-cli.mjs asset register 42 --name "Li Shande"
 # Returns asset #ID (e.g. 7) when active
 ```
 
-### Step 4: Generate Videos Scene by Scene
+### Step 5: Generate Videos Scene by Scene
 
 Use `asset:<asset_id>:reference_image` to anchor character appearance in every scene.
 
@@ -86,7 +121,7 @@ For scenes with multiple characters, combine assets:
   --materials "asset:7:reference_image,asset:8:reference_image"
 ```
 
-### Step 5: Review and Iterate
+### Step 6: Review and Iterate
 
 Check each video result. If a scene needs adjustment, regenerate with the same asset references to maintain consistency.
 
@@ -165,7 +200,7 @@ All commands follow the pattern:
 node ${CLAUDE_SKILL_DIR}/renoise-cli.mjs <domain> <action> [options]
 ```
 
-Four domains: `task`, `material`, `character`, `credit`
+Five domains: `task`, `material`, `character`, `asset`, `credit`
 
 ### Check Balance
 
@@ -273,7 +308,7 @@ node ${CLAUDE_SKILL_DIR}/scripts/match-materials.mjs --pool pool.json --shots pr
 
 See [Material Pool](#material-pool) section above for full details.
 
-### Character Browsing
+### Character Library Browsing
 
 ```bash
 node ${CLAUDE_SKILL_DIR}/renoise-cli.mjs character list                              # List available characters
@@ -288,9 +323,9 @@ node ${CLAUDE_SKILL_DIR}/renoise-cli.mjs task tags                          # Li
 node ${CLAUDE_SKILL_DIR}/renoise-cli.mjs task tag <id> --tags a,b,c         # Update task tags
 ```
 
-### Asset Registration (User Assets)
+### Assets — Stable Reusable Anchors
 
-Register uploaded images as **Ark assets** so they bypass face/privacy detection when used as `reference_image`. This is the recommended way to use AI-generated character images for consistent character appearance across video segments.
+Register uploaded images as **Ark assets** so they become reusable, face-safe anchors when used as `reference_image`. This is the recommended way to use AI-generated character images for consistent character appearance across video segments, and it aligns with the platform's asset-first direction.
 
 ```bash
 # One-step: create + wait until active
@@ -471,7 +506,8 @@ The storyboard grid method produces the best visual consistency by anchoring eac
 
 | Approach | Visual Consistency | Privacy Risk | Setup Effort |
 |----------|-------------------|--------------|--------------|
-| **Storyboard Grid (preferred)** | Highest — all panels share style context | Low — faces are small in grid cells | Medium |
+| **Asset + scene anchor + storyboard** | Highest — identity + environment + shared visual DNA | Lowest practical risk | Medium-High |
+| Storyboard Grid only | Medium-High — strong style context, weaker identity locking | Low-Medium | Medium |
 | Text-to-Video (fallback) | Lower — style varies per call | None | Low |
 | Individual ref_image | Medium | High — close-up faces trigger blocking | Medium |
 
@@ -501,9 +537,9 @@ The storyboard grid method produces the best visual consistency by anchoring eac
 
 | Signal | Approach |
 |--------|----------|
-| Any project with recurring characters | **Storyboard grid** (preferred) |
-| Product shots, landscapes, no people | Image-to-Video with individual ref_image |
-| Grid ref_image blocked by privacy detection | **Text-to-Video** (fallback) |
+| Recurring people + recurring scenes | **Asset / Character Library + scene anchors + optional storyboard** |
+| Product shots, landscapes, no people | Image-to-Video with individual `ref_image` |
+| Grid `ref_image` blocked by privacy detection | Asset / Character Library for people + text or scene anchors for the rest |
 | Quick one-off generation, no consistency needs | Text-to-Video |
 
 ---
@@ -524,6 +560,16 @@ The storyboard grid method produces the best visual consistency by anchoring eac
 - End the last segment with "frame holds steady" for clean endings or easy continuation
 
 **Negative prompting:** Describe what you want, not what you don't want. The model responds best to positive, descriptive language.
+
+---
+
+## Face-Safe Human Anchors
+
+For human identity consistency, there are two first-class anchor paths:
+- **User Assets** — best for new custom characters you generate or upload
+- **Character Library** — best for pre-existing platform characters
+
+Use either of these before falling back to raw materials or text-only.
 
 ---
 
@@ -578,9 +624,9 @@ node ${CLAUDE_SKILL_DIR}/renoise-cli.mjs task generate \
 
 ---
 
-## Character Library — The Correct Way to Handle Human Faces
+## Character Library — Face-Safe Platform Characters
 
-The Renoise platform has a **Character Library** for managing human face/body references. This is the **primary and recommended** way to maintain character consistency across video segments and avoid `PrivacyInformation` errors.
+The Renoise platform has a **Character Library** for managing human face/body references. This is a first-class face-safe anchor path for maintaining character consistency across video segments and avoiding `PrivacyInformation` errors.
 
 ### Why Character Library?
 
@@ -621,11 +667,12 @@ When using `--characters`, the CLI sends `{ "character_id": ID, "role": "referen
 
 | Scenario | Approach |
 |----------|----------|
-| Characters exist in the library | `--characters "ID"` (strongest consistency, no privacy issues) |
-| No characters in library, custom project | Create characters on https://www.renoise.ai first, then use `--characters` |
-| Quick generation, no library setup | **Text-to-Video** with detailed Character Bible (no materials at all) |
-| Product/landscape images (no faces) | `--materials "ID:ref_image"` (safe, no privacy issues) |
-| Storyboard grids with small figures | May or may not trigger — test first; fall back to text-only |
+| Existing reusable platform character | `--characters "ID"` |
+| New custom recurring person with generated or uploaded face reference | **User Asset** → `asset register` → `asset:ID:reference_image` |
+| No reusable face-safe anchor available yet | Create one before multi-scene execution |
+| Quick one-off with low identity importance | **Text-to-Video** with detailed Character Bible |
+| Product/landscape images (no faces) | `--materials "ID:ref_image"` |
+| Storyboard grids with small figures | Use for style/composition only, not as the primary face anchor |
 
 ### What NOT to Do
 

--- a/skills/renoise-gen/references/api-endpoints.md
+++ b/skills/renoise-gen/references/api-endpoints.md
@@ -31,15 +31,34 @@ All endpoints require `X-API-Key: <api_key>` header.
 
 | Method | Path                                       | Description                       |
 | ------ | ------------------------------------------ | --------------------------------- |
-| POST   | `/api/public/v1/materials/upload`          | Upload material (multipart)       |
+| POST   | `/api/public/v1/materials/upload`          | Upload raw material (multipart)   |
 | GET    | `/api/public/v1/materials?type=X&search=Y` | List materials with download URLs |
+
+> **Important:** materials are raw inputs. They are great for products, environments, motion refs, and temporary uploads, but they are not automatically the right long-lived anchor for recurring human identity.
+
+### Assets
+
+Assets are reusable anchors distinct from raw materials. Use them when you need stable, face-safe references across multiple generations.
+
+Common CLI operations:
+- `asset register <material_id> --name "..."`
+- `asset create <material_id> --name "..."`
+- `asset wait <id>`
+- `asset list`
+- `asset get <id>`
+- `asset delete <id>`
+
+Typical use in generation:
+- `--materials "asset:27:reference_image"`
 
 ### Characters
 
-| Method | Path                                                                              | Description      |
-| ------ | --------------------------------------------------------------------------------- | ---------------- |
+| Method | Path                                                                               | Description      |
+| ------ | ---------------------------------------------------------------------------------- | ---------------- |
 | GET    | `/api/public/v1/characters?category=X&usage_group=Y&search=Z&page=1&page_size=20` | List characters  |
-| GET    | `/api/public/v1/characters/:id`                                                   | Character detail |
+| GET    | `/api/public/v1/characters/:id`                                                    | Character detail |
+
+> Characters are platform-managed face-safe human anchors. Prefer characters or assets for recurring people; prefer materials for non-face references.
 
 ## Request/Response Formats
 
@@ -128,7 +147,15 @@ Response:
 - `ref_video` — Reference video (affects pricing)
 - `ref_image` — Reference image
 - `image1`, `image2` — Additional reference images
-- `reference_image` — Character reference image
+- `reference_image` — Character or asset reference image
+
+## Anchor Guidance
+
+Use the reference system intentionally:
+- **Asset** → best reusable anchor for recurring custom human identity
+- **Character** → best reusable anchor for pre-existing platform humans
+- **Material** → best for products, environments, objects, motion refs, and temporary inputs
+- **Storyboard panel** → best as a style/composition support anchor, not the primary face anchor
 
 ## Aspect Ratios
 

--- a/skills/renoise-gen/references/video-capabilities.md
+++ b/skills/renoise-gen/references/video-capabilities.md
@@ -64,7 +64,7 @@ Default to **Text-to-Video** and describe character appearance entirely in text.
 - Pure product photos (white background, no faces) → `ref_image`
 - Abstract/landscape references → `ref_image`
 - Precise motion replication (no faces) → `ref_video`
-- **Human faces → use the Character Library** (`--characters "ID"`) or **User Assets** (`asset register`). Create characters on https://www.renoise.ai or register AI-generated character sheets as assets. **Do NOT** pass face images as `ref_image` — privacy detection will block them.
+- **Human faces → use a face-safe anchor**: **User Assets** (`asset register`) or **Character Library** (`--characters "ID"`). Create characters on https://www.renoise.ai or register AI-generated character sheets as assets. **Do NOT** pass face images as `ref_image` — privacy detection will block them.
 
 ## Duration Strategy
 
@@ -330,12 +330,12 @@ Without ref_image: "Cinematic period drama, warm golden palette,
 ```
 
 ### Priority order for consistency
-1. `--characters "ID"` (strongest — exact face/body from Character Library; no privacy detection issues)
+1. `--materials "asset:ID:reference_image"` or `--characters "ID"` (strongest reusable face-safe anchors)
 2. `--materials "ID:ref_video"` (strong — continues from previous segment visually)
-3. `--materials "ID:ref_image"` with concept art (medium — locks style/palette; **must NOT contain human faces**)
+3. `--materials "ID:ref_image"` with concept art / environment refs (medium — locks style/palette; **must NOT contain human faces**)
 4. Text-only anchor (weakest — model may drift, but safest for any content)
 
-> **Key insight**: `ref_image` and `ref_video` trigger privacy detection if they contain human faces. The Character Library exists precisely to solve this — once a face is registered there, it can be referenced safely via `--characters`.
+> **Key insight**: `ref_image` and `ref_video` trigger privacy detection if they contain human faces. Face-safe anchors solve this: use **assets** for custom recurring humans and **Character Library** for platform-managed humans.
 
 ## Narrative Continuity
 


### PR DESCRIPTION
# Summary

 Refactor the Renoise plugin skills around a stricter Plan → Execute workflow and shift the reference model toward an anchor-first / asset-first approach.

 This change is aimed at improving multi-shot reliability, reducing skipped planning steps, and aligning the docs with the current product direction where reusable anchors matter more than ad-hoc prompting.


# What changed

 ### Director skill

 - introduce explicit Plan and Execute states
 - add plan freeze requirements before prompt writing / generation
 - add stage contracts with required inputs, outputs, and blocking conditions
 - make execution fall back to planning when critical details are missing

 ### Visual development

 - move from a character-only framing toward a broader Anchor Registry
 - treat recurring people, environments, products, props, and continuity seams as anchorable elements
 - require explicit shot-to-anchor mapping and continuity strategy for multi-clip work

 ### Prompt / generation workflow

 - make prompts consume a frozen anchor plan instead of compensating for missing planning
 - strengthen pre-flight checks around anchor integrity
 - expand continuity guidance beyond character consistency into environment / prop / seam continuity

 ### Renoise generation docs

 - clarify the distinction between:
     - assets
     - character library
     - materials
     - storyboard refs
     - text-only fallback
 - elevate assets as reusable, durable anchors rather than treating materials as equivalent
 - align face-safe guidance around User Assets + Character Library

 ### Examples / references

 - update the mystery package example to match the new workflow
 - keep the 15s segment rule consistent with the documented generation model

# Why

 Previously, the docs made it too easy for the agent to:
 - move into prompt writing too early
 - treat raw materials as interchangeable with stable anchors
 - under-plan scene / prop / continuity references
 - discover critical gaps only after generation had already started

 The new structure makes the workflow more intentional:

 ```text
   idea
   -> plan
   -> freeze anchors / continuity / strategy
   -> execute
   -> review
 ```

 instead of:

 ```text
   idea
   -> prompt early
   -> generate
   -> patch missing references later
 ```

# Expected UX impact

 Users should see:
 - more up-front planning for multi-shot projects
 - clearer handling of recurring people / scenes / props
 - better continuity decisions before generation starts
 - fewer wasted retries caused by missing anchors

 In short: slightly slower start, much more stable execution.