### PR TITLE
chore: 增加用户反馈 issue 模板 + README 反馈指引

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,53 @@
+name: 🐞 Bug 报告 / Bug report
+description: 报告一个可复现的功能缺陷 / Report a reproducible defect
+title: "[Bug] "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        请给出可复现的步骤；涉及生成的附上 **Task ID**（`task get <id>` 可查）。
+        Please include reproducible steps; attach the **Task ID** for generation issues.
+        > 账户 / 余额 / API Key 问题请到 https://www.renoise.ai/developer，不在本仓库。
+
+  - type: input
+    id: host-version
+    attributes:
+      label: 环境 / 版本 / Host & version
+      placeholder: "e.g. Claude Code · renoise 1.0.0 · macOS · node 20"
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: 复现步骤 / Steps to reproduce
+      placeholder: |
+        1. …（触发语 / 命令）
+        2. …
+        3. …
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: 期望结果 / Expected
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: 实际结果（含报错原文）/ Actual (paste the error text)
+    validations:
+      required: true
+
+  - type: input
+    id: task-ids
+    attributes:
+      label: Task ID(s)（如涉及生成）/ Task ID(s) (if a generation)
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: 日志 / 截图 / Logs or screenshots
+      render: shell

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -6,48 +6,38 @@ body:
   - type: markdown
     attributes:
       value: |
-        请给出可复现的步骤；涉及生成的附上 **Task ID**（`task get <id>` 可查）。
-        Please include reproducible steps; attach the **Task ID** for generation issues.
-        > 账户 / 余额 / API Key 问题请到 https://www.renoise.ai/developer，不在本仓库。
+        涉及生成的缺陷请附 **Task ID**（`task get <id>` 可查）。
+        For generation defects, include the **Task ID** (`task get <id>`).
+        > 账户 / 余额 / API Key 问题请到 https://www.renoise.ai/developer ，不在本仓库。
 
   - type: input
-    id: host-version
+    id: env
     attributes:
       label: 环境 / 版本 / Host & version
-      placeholder: "e.g. Claude Code · renoise 1.0.0 · macOS · node 20"
+      placeholder: "e.g. Claude Code · renoise 1.0.0 · macOS"
     validations:
       required: true
 
   - type: textarea
     id: steps
     attributes:
-      label: 复现步骤 / Steps to reproduce
+      label: 怎么复现 / Steps to reproduce
       placeholder: |
         1. …（触发语 / 命令）
         2. …
-        3. …
     validations:
       required: true
 
   - type: textarea
-    id: expected
+    id: result
     attributes:
-      label: 期望结果 / Expected
-
-  - type: textarea
-    id: actual
-    attributes:
-      label: 实际结果（含报错原文）/ Actual (paste the error text)
+      label: 出了什么问题 / What went wrong
+      description: 实际结果（贴报错原文）+ 你期望的结果 / Actual result (paste the error) + what you expected
     validations:
       required: true
 
-  - type: input
-    id: task-ids
-    attributes:
-      label: Task ID(s)（如涉及生成）/ Task ID(s) (if a generation)
-
   - type: textarea
-    id: logs
+    id: details
     attributes:
-      label: 日志 / 截图 / Logs or screenshots
-      render: shell
+      label: 补充（可选）/ Details (optional)
+      description: Task ID、日志、截图；图片可直接拖拽。/ Task ID(s), logs, screenshots — drag & drop images here.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 账户 / 余额 / API Key — Account, credits & API keys
+    url: https://www.renoise.ai/developer
+    about: 账户、余额、API Key 相关请到平台处理，不在本仓库提 issue。/ Account, credits, and API-key matters are handled on the platform, not here.

--- a/.github/ISSUE_TEMPLATE/feedback.yml
+++ b/.github/ISSUE_TEMPLATE/feedback.yml
@@ -1,14 +1,14 @@
 name: 💬 体验反馈 / Experience feedback
-description: 分享使用体验、生成质量、一致性或工作流建议 / Share usage experience, generation quality, consistency, or workflow suggestions
+description: 分享使用体验、生成质量、一致性或工作流建议 / Share experience, quality, consistency, or workflow suggestions
 title: "[Feedback] "
 labels: ["feedback"]
 body:
   - type: markdown
     attributes:
       value: |
-        感谢反馈！涉及生成结果时，**Task ID** 和产物链接/截图最有帮助（`task get <id>` 可查 ID）。
-        Thanks! When it involves a generation, the **Task ID** and an output link/screenshot help the most.
-        > 账户 / 余额 / API Key 问题请到 https://www.renoise.ai/developer 处理，不在本仓库。
+        感谢反馈！涉及生成时，附上 **Task ID**（`task get <id>` 可查）和产物链接/截图最有帮助。
+        Thanks! A **Task ID** + output link/screenshot help the most when it involves a generation.
+        > 账户 / 余额 / API Key 问题请到 https://www.renoise.ai/developer ，不在本仓库。
 
   - type: dropdown
     id: area
@@ -17,12 +17,12 @@ body:
       description: 可多选 / Select all that apply
       multiple: true
       options:
-        - 生成质量（清晰度 / 画面）/ Generation quality
-        - 跨镜头一致性（人物 / 画风 / 色调 / 道具）/ Cross-shot consistency
-        - 衔接 / 转场 / Shot transitions
-        - 工作流 / 交互体验 / Workflow & interaction
-        - 模型选择 / 默认 / Model choice & defaults
-        - 安装 / 配置 / API Key / Setup & config
+        - 生成质量 / Quality
+        - 跨镜头一致性 / Consistency
+        - 衔接 · 转场 / Transitions
+        - 工作流 · 交互 / Workflow
+        - 模型 · 默认 / Models & defaults
+        - 安装 · 配置 / Setup
         - 文档 / Docs
         - 其他 / Other
     validations:
@@ -40,49 +40,17 @@ body:
     validations:
       required: true
 
-  - type: input
-    id: version
-    attributes:
-      label: 插件版本 / Plugin version
-      placeholder: "e.g. 1.0.0"
-
-  - type: input
-    id: skill-model
-    attributes:
-      label: 涉及的 skill / 模型 / Skill or model
-      placeholder: "e.g. director / renoise-gen；seedance-2.0 / seedream-5-0-pro"
-
   - type: textarea
-    id: request
+    id: feedback
     attributes:
-      label: 你的需求 / 触发语 / What you asked for
-      placeholder: "e.g. 帮我做个 1 分钟东方玄幻短剧，竖屏"
-
-  - type: textarea
-    id: expected
-    attributes:
-      label: 期望的效果 / What you expected
-
-  - type: textarea
-    id: actual
-    attributes:
-      label: 实际发生了什么 / What actually happened
+      label: 你的反馈 / Your feedback
+      description: 做了什么、哪里不满意或惊喜、期望是什么 / What you did, what was off (or great), and what you expected
+      placeholder: "e.g. 让它做 1 分钟玄幻短剧，跨段人物脸不一致；期望全程同一张脸。"
     validations:
       required: true
 
-  - type: input
-    id: task-ids
-    attributes:
-      label: Task ID(s)
-      placeholder: "e.g. 109227, 109228"
-
   - type: textarea
-    id: evidence
+    id: details
     attributes:
-      label: 产物链接 / 截图 / Output link or screenshot
-      description: 可直接把图片或视频拖拽到这里 / Drag & drop images or videos here
-
-  - type: textarea
-    id: suggestion
-    attributes:
-      label: 改进建议（可选）/ Suggestion (optional)
+      label: 补充（可选）/ Details (optional)
+      description: 涉及生成请附 Task ID + 产物链接/截图，可写插件版本；图片可直接拖拽。/ Task ID(s), output link/screenshot, plugin version — drag & drop images here.

--- a/.github/ISSUE_TEMPLATE/feedback.yml
+++ b/.github/ISSUE_TEMPLATE/feedback.yml
@@ -1,0 +1,88 @@
+name: 💬 体验反馈 / Experience feedback
+description: 分享使用体验、生成质量、一致性或工作流建议 / Share usage experience, generation quality, consistency, or workflow suggestions
+title: "[Feedback] "
+labels: ["feedback"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        感谢反馈！涉及生成结果时，**Task ID** 和产物链接/截图最有帮助（`task get <id>` 可查 ID）。
+        Thanks! When it involves a generation, the **Task ID** and an output link/screenshot help the most.
+        > 账户 / 余额 / API Key 问题请到 https://www.renoise.ai/developer 处理，不在本仓库。
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: 反馈类别 / Area
+      description: 可多选 / Select all that apply
+      multiple: true
+      options:
+        - 生成质量（清晰度 / 画面）/ Generation quality
+        - 跨镜头一致性（人物 / 画风 / 色调 / 道具）/ Cross-shot consistency
+        - 衔接 / 转场 / Shot transitions
+        - 工作流 / 交互体验 / Workflow & interaction
+        - 模型选择 / 默认 / Model choice & defaults
+        - 安装 / 配置 / API Key / Setup & config
+        - 文档 / Docs
+        - 其他 / Other
+    validations:
+      required: true
+
+  - type: dropdown
+    id: host
+    attributes:
+      label: 使用环境 / Host
+      options:
+        - Claude Code
+        - Codex
+        - OpenClaw
+        - 其他 / Other
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: 插件版本 / Plugin version
+      placeholder: "e.g. 1.0.0"
+
+  - type: input
+    id: skill-model
+    attributes:
+      label: 涉及的 skill / 模型 / Skill or model
+      placeholder: "e.g. director / renoise-gen；seedance-2.0 / seedream-5-0-pro"
+
+  - type: textarea
+    id: request
+    attributes:
+      label: 你的需求 / 触发语 / What you asked for
+      placeholder: "e.g. 帮我做个 1 分钟东方玄幻短剧，竖屏"
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: 期望的效果 / What you expected
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: 实际发生了什么 / What actually happened
+    validations:
+      required: true
+
+  - type: input
+    id: task-ids
+    attributes:
+      label: Task ID(s)
+      placeholder: "e.g. 109227, 109228"
+
+  - type: textarea
+    id: evidence
+    attributes:
+      label: 产物链接 / 截图 / Output link or screenshot
+      description: 可直接把图片或视频拖拽到这里 / Drag & drop images or videos here
+
+  - type: textarea
+    id: suggestion
+    attributes:
+      label: 改进建议（可选）/ Suggestion (optional)

--- a/README.md
+++ b/README.md
@@ -143,3 +143,14 @@ git submodule add https://github.com/ArcoCodes/renoise-plugins-official.git plug
 - Multi-shot narrative workflow: story gate → consistency manifest (characters / props / scenes / style bible / transitions / spoken language), post-generation QC.
 - New capabilities: audio (`lyria-clip`, `seed-audio-1.0`), quality enhancement / upscale, `seedream-5-0-pro`, `gemini-omni-flash` source-video editing.
 - Faces on the `seedance-2.0` series pass straight through as `ref_image` (auto-facepass); the legacy API-key pre-tool hook and the deprecated `asset`/`character` commands were removed.
+
+## Feedback / 反馈
+
+Hit a bug or have feedback on the experience, generation quality, or cross-shot consistency? Open an issue — the repo ships guided forms:
+
+- 💬 **[Experience feedback](https://github.com/ArcoCodes/renoise-plugins-official/issues/new?template=feedback.yml)** — usage experience, generation quality, consistency, workflow suggestions.
+- 🐞 **[Bug report](https://github.com/ArcoCodes/renoise-plugins-official/issues/new?template=bug_report.yml)** — reproducible defects.
+
+When it involves a generation, include the **Task ID** (`task get <id>`) and an output link/screenshot — that helps us most. Account / credits / API-key matters go to https://www.renoise.ai/developer, not the issue tracker.
+
+有体验反馈或遇到 bug？到 **Issues → New issue** 选「💬 体验反馈」或「🐞 Bug 报告」按表单填写；涉及生成请附 **Task ID** 和产物链接/截图。账户 / 余额 / API Key 问题请到 https://www.renoise.ai/developer。


### PR DESCRIPTION
## 概述
按业界标准（GitHub Issue Forms）新增引导式反馈入口，方便用户提体验反馈与 bug；并在 README 增加「反馈」指引。纯附加，不影响插件本体。

## 改动
- `.github/ISSUE_TEMPLATE/feedback.yml` — 💬 体验反馈表单：反馈类别（质量/一致性/衔接/工作流/模型/配置/文档，多选）、使用环境、版本、涉及 skill·模型、需求触发语、期望、实际（必填）、**Task ID**、产物链接/截图、改进建议。中英双语。
- `.github/ISSUE_TEMPLATE/bug_report.yml` — 🐞 可复现缺陷表单。
- `.github/ISSUE_TEMPLATE/config.yml` — 关闭空白 issue（引导进模板）+ 账户/余额/API Key 类问题外链到平台。
- `README.md` — 新增 **Feedback / 反馈** 小节，指引用户按表单反馈、涉及生成附 Task ID + 产物链接。

## 效果
用户点 **New issue** 会先看到「体验反馈 / Bug 报告」两个引导表单，按字段填写；账户/Key 类问题被引导到 renoise.ai/developer，不占用 issue tracker。

🤖 Generated with [Claude Code](https://claude.com/claude-code)