### PR TITLE
fix(setup): auto-ensure latest managed CLI on gen preflight

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
   "plugins": [
     {
       "name": "renoise",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "source": "./",
       "description": "AI video production skills — creative direction, generation, editing, and e-commerce content"
     }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "renoise",
   "description": "AI video production skills — creative direction, generation, editing, and e-commerce content",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "author": {
     "name": "Renoise"
   },

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "renoise",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "AI video production skills — creative direction, generation, editing, and e-commerce content",
   "author": {
     "name": "Renoise"

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "renoise",
   "name": "Renoise",
   "description": "AI video production skills — creative direction, generation, editing, and e-commerce content",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "configSchema": {
     "type": "object",
     "additionalProperties": false,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@renoise/plugin",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "license": "Apache-2.0",
   "type": "module",
   "description": "AI video production skills — creative direction, generation, editing, and e-commerce content",

--- a/skills/renoise-gen/SKILL.md
+++ b/skills/renoise-gen/SKILL.md
@@ -15,7 +15,7 @@ allowed-tools: Bash, Read, Write, Glob
 user-invocable: false
 metadata:
   author: renoise
-  version: 0.7.0
+  version: 0.7.1
   category: video-production
   tags: [general, video-generation, image-generation, material-pool]
 ---
@@ -31,6 +31,10 @@ The native `renoise` binary is the only source of truth for authentication, comm
 Run this at the start of every generation session:
 
 ```bash
+# Keep the managed CLI on the latest public release (no user prompt).
+node "${CLAUDE_SKILL_DIR}/../renoise-setup/scripts/install-cli.mjs" --ensure
+# Prefer the managed install for this shell (Unix).
+export PATH="${HOME}/.local/bin:${PATH}"
 command -v renoise >/dev/null 2>&1 || exit 127
 renoise version
 renoise help task create | grep -q -- '--prompt-file'
@@ -40,7 +44,7 @@ renoise auth status --json
 renoise model --json
 ```
 
-On Windows PowerShell, use `Get-Command renoise` instead of `command -v`, and confirm task help contains `renoise task create` plus `--prompt-file` and `renoise task wait`, and auth help contains `renoise auth exec`, instead of using `grep`. If the binary, required commands, or authentication is missing, immediately read `${CLAUDE_SKILL_DIR}/../renoise-setup/SKILL.md` completely and follow it through readiness, asking only for approvals required before host changes or browser authorization. Then rerun preflight and continue the original request; do not merely direct the user to **Setup / Account**. Never ask the user to paste an API key into chat.
+On Windows PowerShell, run the same `node ... install-cli.mjs --ensure`, then prepend `$env:LOCALAPPDATA\Renoise\bin` to `$env:Path`. Use `Get-Command renoise` instead of `command -v`, and confirm task help contains `renoise task create` plus `--prompt-file` and `renoise task wait`, and auth help contains `renoise auth exec`, instead of using `grep`. If `--ensure` fails, the binary is still missing, required commands are absent, or authentication is missing, immediately read `${CLAUDE_SKILL_DIR}/../renoise-setup/SKILL.md` completely and follow it through readiness, asking only for approvals required before host PATH edits or browser authorization. Then rerun preflight and continue the original request; do not merely direct the user to **Setup / Account**. Never ask the user to paste an API key into chat.
 
 ## Select a Model Dynamically
 

--- a/skills/renoise-setup/SKILL.md
+++ b/skills/renoise-setup/SKILL.md
@@ -6,7 +6,7 @@ description: >
   missing RENOISE_API_KEY, ffmpeg, jq, yt-dlp, ImageMagick, or agent-browser.
 metadata:
   author: renoise
-  version: 1.0.0
+  version: 1.0.1
   category: setup
   tags: [setup, install, authentication, dependencies, renoise]
 ---
@@ -42,26 +42,34 @@ renoise help auth login
 
 The outputs must contain the exact usage paths `renoise task create`, `renoise task wait`, and `renoise auth exec`, the task flag `--prompt-file`, plus the `auth login` flag `--web`; older Cobra builds may show parent help and still exit successfully.
 
-If the binary is missing, either exact usage path is absent, or the user explicitly asks for an update, resolve `<PLUGIN_ROOT>` and preview the installer. This reads `https://download.renoise.ai/cli/latest.json` and prints the installed path/version/compatibility plus the latest release, archive, and target; it does not download or change files:
+Generation preflight auto-keeps the **managed** CLI current. It reads `https://download.renoise.ai/cli/latest.json` and installs/replaces only the managed target when missing, incompatible, or older than the latest public release — no prompt:
+
+```text
+node "<PLUGIN_ROOT>/skills/renoise-setup/scripts/install-cli.mjs" --ensure
+```
+
+| Host | Managed target |
+|---|---|
+| macOS / Linux | `~/.local/bin/renoise` |
+| Windows | `%LOCALAPPDATA%\Renoise\bin\renoise.exe` |
+
+After `--ensure`, prefer that managed binary for the session (`export PATH="$HOME/.local/bin:$PATH"` on Unix, or prepend `%LOCALAPPDATA%\Renoise\bin` on Windows). `--ensure` never edits shell profiles or the Windows user environment.
+
+For a dry run (no downloads), or when the user explicitly asks to inspect/install outside generation:
 
 ```text
 node "<PLUGIN_ROOT>/skills/renoise-setup/scripts/install-cli.mjs" --check
 ```
 
-The installer supports macOS, Windows, and Linux on x64 or ARM64. It selects `.tar.gz` on macOS/Linux or `.zip` on Windows, verifies the archive against the release's `checksums.txt`, and installs to:
+The installer supports macOS, Windows, and Linux on x64 or ARM64. It selects `.tar.gz` on macOS/Linux or `.zip` on Windows and verifies the archive against the release's `checksums.txt`.
 
-| Host | Default target |
-|---|---|
-| macOS / Linux | `~/.local/bin/renoise` |
-| Windows | `%LOCALAPPDATA%\Renoise\bin\renoise.exe` |
-
-Show the installed and latest versions, detected release archive, whether the target will replace an existing file, and target path. If the current version is already compatible, do not force an update during unrelated work. **Ask for explicit confirmation.** Only after approval run:
+Show the installed and latest versions, detected release archive, whether the target will replace an existing file, and target path. For **manual** `--install` outside generation preflight, **ask for explicit confirmation** first, then run:
 
 ```text
 node "<PLUGIN_ROOT>/skills/renoise-setup/scripts/install-cli.mjs" --install
 ```
 
-The same path handles first install and replacement updates. It does not auto-update in the background, and it never edits `PATH`. If the target directory is absent from `PATH` or another `renoise` binary wins PATH resolution, explain the platform-specific change and ask separately before editing shell profiles or the Windows user environment. Restart Codex/ChatGPT Desktop or Claude Desktop after a PATH change. Linux has no official Codex Desktop app, but the same CLI and skills work in Codex CLI and Claude Code.
+If the managed target directory is absent from `PATH` or another `renoise` binary wins PATH resolution, explain the platform-specific change and ask separately before editing shell profiles or the Windows user environment. Restart Codex/ChatGPT Desktop or Claude Desktop after a PATH change. Linux has no official Codex Desktop app, but the same CLI and skills work in Codex CLI and Claude Code.
 
 For manual installation, read the public release manifest at `https://download.renoise.ai/cli/latest.json`, download the matching archive and `checksums.txt` from its version directory, verify SHA-256, then extract the binary. Downloading, moving, or replacing files still requires confirmation.
 

--- a/skills/renoise-setup/scripts/install-cli.mjs
+++ b/skills/renoise-setup/scripts/install-cli.mjs
@@ -210,32 +210,79 @@ async function install(plan) {
   }
 }
 
+function managedInstall(info) {
+  if (!existsSync(info.target)) return null;
+  try {
+    const path = resolve(info.target);
+    const versionOutput = execFileSync(path, ['version'], { encoding: 'utf8' }).trim();
+    const createHelp = execFileSync(path, ['help', 'task', 'create'], { encoding: 'utf8' });
+    const waitHelp = execFileSync(path, ['help', 'task', 'wait'], { encoding: 'utf8' });
+    const authHelp = execFileSync(path, ['help', 'auth', 'exec'], { encoding: 'utf8' });
+    const loginHelp = execFileSync(path, ['help', 'auth', 'login'], { encoding: 'utf8' });
+    return {
+      path,
+      version: versionOutput.match(/\b(v?\d+\.\d+\.\d+)\b/)?.[1]?.replace(/^v/, '') || 'unknown',
+      versionOutput,
+      compatible: hasRequiredCommands(createHelp, waitHelp, authHelp, loginHelp),
+    };
+  } catch {
+    return { path: resolve(info.target), version: 'unknown', versionOutput: 'unreadable', compatible: false };
+  }
+}
+
+function needsManagedUpdate(managed, latestVersion) {
+  if (!managed) return true;
+  if (!managed.compatible || managed.version === 'unknown') return true;
+  return compareVersions(managed.version, latestVersion) < 0;
+}
+
+function printBinaryHints(info) {
+  console.log(`Binary: ${info.target}`);
+  console.log(`PathPrepend: ${info.binDir}`);
+  console.log(pathMessage(info));
+}
+
 async function main() {
   const mode = process.argv[2] || '--check';
-  if (!['--check', '--install'].includes(mode)) throw new Error('Usage: install-cli.mjs [--check|--install]');
+  if (!['--check', '--install', '--ensure'].includes(mode)) {
+    throw new Error('Usage: install-cli.mjs [--check|--install|--ensure]');
+  }
 
   const plan = await releasePlan();
   const latestVersion = plan.release.tag_name.replace(/^v/, '');
+  const managed = managedInstall(plan.info);
   console.log(`Platform: ${plan.info.label} ${plan.info.arch.label}`);
   console.log(`Installed: ${plan.installed ? `${plan.installed.versionOutput} at ${plan.installed.path} (${plan.installed.compatible ? 'compatible' : 'incompatible'})` : 'not found'}`);
+  console.log(`Managed: ${managed ? `${managed.versionOutput} at ${managed.path} (${managed.compatible ? 'compatible' : 'incompatible'})` : 'not found'}`);
   console.log(`Latest release: ${plan.release.tag_name}`);
   console.log(`Archive: ${plan.archive.name}`);
   console.log(`Target: ${plan.info.target}${existsSync(plan.info.target) ? ' (will replace existing file)' : ''}`);
 
   if (mode === '--check') {
     console.log('No files changed. Run again with --install only after the user explicitly approves this install or update.');
+    console.log('Agent preflight may use --ensure to keep the managed install on the latest public release without a prompt.');
+    printBinaryHints(plan.info);
     return;
   }
 
-  if (plan.installed && plan.installed.version !== 'unknown' && compareVersions(plan.installed.version, latestVersion) >= 0) {
+  // --install keeps the old PATH-aware short-circuit for manual upgrades.
+  if (mode === '--install' && plan.installed && plan.installed.version !== 'unknown' && compareVersions(plan.installed.version, latestVersion) >= 0) {
     if (!plan.installed.compatible) throw new Error(`Installed CLI ${plan.installed.version} does not satisfy the plugin contract and no newer public release is available`);
     console.log(`${plan.installed.version === latestVersion ? 'Already current' : 'Installed version is newer than the latest release'} and compatible: ${plan.installed.path}`);
+    printBinaryHints(plan.info);
+    return;
+  }
+
+  // --ensure only mutates the managed target so a stale brew/PATH binary cannot block updates.
+  if (mode === '--ensure' && !needsManagedUpdate(managed, latestVersion)) {
+    console.log(`Already current: ${plan.info.target}`);
+    printBinaryHints(plan.info);
     return;
   }
 
   await install(plan);
   console.log(`Installed and verified: ${plan.info.target}`);
-  console.log(pathMessage(plan.info));
+  printBinaryHints(plan.info);
 }
 
 if (process.argv[1] && pathToFileURL(process.argv[1]).href === import.meta.url) {

--- a/tests/single-source.test.mjs
+++ b/tests/single-source.test.mjs
@@ -106,14 +106,19 @@ test('installer selects and verifies macOS, Windows, and Linux archives', () => 
   assert.equal(compareVersions('0.2.0', '0.2.0'), 0);
 });
 
-test('setup only installs after explicit approval', () => {
+test('setup keeps managed CLI current and still gates manual install', () => {
   const setup = readFileSync('skills/renoise-setup/SKILL.md', 'utf8');
+  const gen = readFileSync('skills/renoise-gen/SKILL.md', 'utf8');
+  const installer = readFileSync('skills/renoise-setup/scripts/install-cli.mjs', 'utf8');
   assert.match(setup, /https:\/\/download\.renoise\.ai\/cli\/latest\.json/);
   assert.doesNotMatch(setup, /GitHub Releases|go install/);
   assert.match(setup, /--check/);
-  assert.match(setup, /Ask for explicit confirmation/);
+  assert.match(setup, /--ensure/);
+  assert.match(setup, /ask for explicit confirmation/i);
   assert.match(setup, /--install/);
   assert.match(setup, /renoise auth login --web --json/);
   assert.match(setup, /never ask them to open a terminal/);
-  assert.match(setup, /never edits `PATH`/);
+  assert.match(gen, /install-cli\.mjs" --ensure/);
+  assert.match(installer, /--ensure/);
+  assert.match(installer, /needsManagedUpdate/);
 });


### PR DESCRIPTION
Add install-cli --ensure, prefer the managed binary path during generation sessions, and bump plugin to 1.1.2.