### PR TITLE
fix(ci): publish releases without GitHub CLI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,8 +19,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Tag package version
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        id: version
         run: |
           set -euo pipefail
           version="$(node -p 'require("./package.json").version')"
@@ -29,19 +28,18 @@ jobs:
             exit 1
           fi
           tag="renoise--v${version}"
+          echo "tag=${tag}" >> "$GITHUB_OUTPUT"
           if git rev-parse -q --verify "refs/tags/${tag}" >/dev/null; then
             echo "Tag ${tag} already exists"
-            exit 0
-          fi
-          git tag "$tag" "$GITHUB_SHA"
-          git push origin "refs/tags/${tag}"
-          if gh release view "$tag" >/dev/null 2>&1; then
-            echo "GitHub Release ${tag} already exists"
           else
-            gh release create "$tag" \
-              --title "$tag" \
-              --generate-notes \
-              --latest \
-              --target "$GITHUB_SHA"
+            git tag "$tag" "$GITHUB_SHA"
+            git push origin "refs/tags/${tag}"
           fi
-          echo "Published ${tag}"
+      - name: Publish GitHub Release
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
+        with:
+          tag_name: ${{ steps.version.outputs.tag }}
+          name: ${{ steps.version.outputs.tag }}
+          generate_release_notes: true
+          make_latest: true
+          target_commitish: ${{ github.sha }}


### PR DESCRIPTION
The 1.5.0 tag was created, but the release job failed because `gh` is unavailable on the runner. Use the already-pinned GitHub Release action after idempotently ensuring the package tag. The 1.5.0 release was completed manually and this fixes future automated releases.