### PR TITLE
feat: add DeepSeek Harness bundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,17 @@ claude plugin install renoise@renoise-plugins-official
 
 In **Cowork**, open **Customize → Plugins → + → Add marketplace → Add from a repository**, enter `https://github.com/ArcoCodes/renoise-plugins-official`, then install **renoise**. Cowork handles local CLI installation and browser sign-in; no separate Terminal is required.
 
+### DeepSeek Harness
+
+Install this checkout into a profile, then run that profile:
+
+```bash
+dsh plugin --profile headless add .
+dsh --profile headless "Create an AI video from my brief."
+```
+
+The bundle registers every skill under `skills/` through DeepSeek Harness's filesystem skill provider. To inspect the composition without making a model request, run `dsh --profile headless --dump-config`.
+
 ### OpenClaw
 
 ```bash

--- a/cordis.patch.yml
+++ b/cordis.patch.yml
@@ -1,0 +1,3 @@
+- insert:
+    - id: renoise
+      name: '@renoise/plugin/dsh.mjs'

--- a/dsh.mjs
+++ b/dsh.mjs
@@ -1,0 +1,14 @@
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { apply as registerSkills } from '@deepseek-ai/dsh-skill-filesystem'
+
+export const name = 'renoise-dsh'
+export const inject = ['skills']
+
+export function apply(ctx) {
+  registerSkills(ctx, {
+    providerName: 'renoise',
+    includeDefaultRoots: false,
+    customSkillDirs: [join(dirname(fileURLToPath(import.meta.url)), 'skills')],
+  })
+}

--- a/package.json
+++ b/package.json
@@ -24,6 +24,17 @@
     "commands/",
     "skills/",
     "src/",
+    "dsh.mjs",
+    "cordis.patch.yml",
     "README.md"
-  ]
+  ],
+  "dsh": {
+    "bundle": {
+      "patch": "./cordis.patch.yml"
+    }
+  },
+  "peerDependencies": {
+    "@deepseek-ai/cordis": "*",
+    "@deepseek-ai/dsh-skill-filesystem": "*"
+  }
 }

--- a/tests/single-source.test.mjs
+++ b/tests/single-source.test.mjs
@@ -125,6 +125,15 @@ test('prompt examples use canonical material ID tokens', () => {
   assert.doesNotMatch(directorFiles, /@[\w-]+\.(?:png|jpe?g|webp|mp4|mov)\b/i);
 });
 
+test('DeepSeek Harness bundle registers the packaged skills', () => {
+  const pkg = readJSON('package.json');
+  assert.equal(pkg.dsh.bundle.patch, './cordis.patch.yml');
+  assert.ok(pkg.files.includes('dsh.mjs'));
+  assert.ok(pkg.files.includes('cordis.patch.yml'));
+  assert.match(readFileSync('cordis.patch.yml', 'utf8'), /@renoise\/plugin\/dsh\.mjs/);
+  assert.match(readFileSync('dsh.mjs', 'utf8'), /customSkillDirs:[\s\S]*'skills'/);
+});
+
 test('package metadata is the manifest source of truth', () => {
   const pkg = readJSON('package.json');
   const manifests = [


### PR DESCRIPTION
## Summary

- declare the package as an installable DeepSeek Harness bundle
- register the packaged skills through the Harness filesystem skill provider
- document local profile installation and config inspection

## Verification

- `npm test`
- `npm pack --dry-run`
- installed the checkout into an isolated Harness headless profile
- `dsh --profile headless --dump-config` includes the Renoise bundle
- headless boot reaches model authentication with the Renoise plugin active