### PR TITLE
feat(routing): refresh current model guidance

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
   "plugins": [
     {
       "name": "renoise",
-      "version": "1.7.0",
+      "version": "1.8.0",
       "source": "./",
       "description": "AI video production skills — creative direction, generation, editing, and e-commerce content"
     }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "renoise",
   "description": "AI video production skills — creative direction, generation, editing, and e-commerce content",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "author": {
     "name": "Renoise"
   },

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "renoise",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "description": "AI video production skills — creative direction, generation, editing, and e-commerce content",
   "author": {
     "name": "Renoise"

--- a/README.md
+++ b/README.md
@@ -85,6 +85,11 @@ renoise settings
 
 ## Version & upgrading
 
+### 1.8.0
+
+- Refreshed model routing, removed obsolete recommendations, and added H3 Max, H3 Max Turbo, and Topaz Starlight guidance.
+- Improved automatic discovery of the internal model-routing skill.
+
 ### 1.7.0
 
 - Split reference-video recreation (`复刻视频` / `剪同款`) into the standalone portable `video-remake` skill.

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "renoise",
   "name": "Renoise",
   "description": "AI video production skills — creative direction, generation, editing, and e-commerce content",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "configSchema": {
     "type": "object",
     "additionalProperties": false,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@renoise/plugin",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "license": "Apache-2.0",
   "type": "module",
   "description": "AI video production skills — creative direction, generation, editing, and e-commerce content",

--- a/skills/manifest.json
+++ b/skills/manifest.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "pluginVersion": "1.7.0",
+  "pluginVersion": "1.8.0",
   "skills": [
     {
       "id": "director",

--- a/skills/model-routing/SKILL.md
+++ b/skills/model-routing/SKILL.md
@@ -7,7 +7,7 @@ description: >
 user-invocable: false
 metadata:
   author: renoise
-  version: 0.1.0
+  version: 0.1.1
   category: media-generation
   tags: [model-routing, prompting, image, video, audio, portable]
 ---
@@ -152,7 +152,8 @@ Use a concise visual description, not a requirements document:
 | Fast Seedance draft | `seedance-2.0-fast-byteplus` | Official speed/cost balance tier. |
 | Lowest-cost/high-volume Seedance draft | `seedance-2.0-mini-byteplus` | Cost-performance tier for iteration and selection. |
 | Short 720p generation, text rendering, or source-video edit within its narrow live contract | `gemini-omni-flash` | Strong short-form instruction following, multi-shot generation, and conversational editing. |
-| Exact first frame, last frame, frame interpolation, focused video references, 2K/4K delivery, or reference audio paired with visual references | `hailuo-h3` | Strong endpoint control and structured multimodal audiovisual direction. |
+| Exact first frame, last frame, frame interpolation, focused video references, 2K delivery, or reference audio paired with visual references | `hailuo-h3` | Strong endpoint control and structured multimodal audiovisual direction. |
+| Fastest, lowest-cost H3-family text-to-video or first/last-frame generation | `h3-max-turbo` | Rapid low-cost iteration when the live contract needs no generic image, video, or audio references; use full H3 instead when references or 2K are required. |
 | Human action, dialogue acting, lip sync, atmospheric commercial work, or concise cinematic multi-shot scenes | `happyhorse-1.0` | Strong motion, physical plausibility, visual depth, and synchronized dialogue/Foley/ambience through the inputs Renoise exposes. |
 | Reusable subjects/products, reference-driven series, identity/voice continuity, or custom multi-shot stories | `kling-3.0-omni` | Reference-first specialist with native audio, subject consistency, and explicit storyboard control. |
 | xAI text-to-video or one-image animation with native sound | `grok-video-1.5` | Current Renoise 1.5 contract is strongest when zero or one image is sufficient. |
@@ -161,6 +162,7 @@ Use a concise visual description, not a requirements document:
 ### Tier and version notes
 
 - Seedance Full, Fast, and Mini are respectively the quality, speed/cost-balance, and cost-performance tiers; live estimates decide the actual trade-off.
+- Within the H3 family, use H3 for 2K or multimodal references, H3 Max for faster official-channel first/last-frame work, and H3 Max Turbo for the fastest and cheapest text/first/last-frame iteration. Never infer reference-to-video support for Max or Turbo when the live roles do not expose it.
 - Grok's public upstream capabilities may move faster than Renoise's contract. Route from live roles and limits rather than assuming an upstream feature is connected.
 - Model preference leaderboards are task-, resolution-, and audio-filter-specific; use them as volatile evidence, not a single aggregate ranking.
 
@@ -199,9 +201,11 @@ Constraints: no subtitles/logo/watermark unless requested.
 - For editing: identify the source, say **change only X**, and list what remains unchanged.
 - Make one edit per turn when possible; use follow-up refinement rather than replacing the entire prompt.
 
-### MiniMax H3 — mode-specific audiovisual plan
+### MiniMax H3 family — mode-specific audiovisual plan
 
-Choose one live mode and prompt accordingly:
+Choose one live mode and prompt accordingly. H3 Max and H3 Max Turbo follow the same first/last-frame prompting pattern when those modes are live, but generic reference mode belongs only to models whose live roles explicitly expose it:
+
+- **Text-to-video:** state the subject, action over time, camera movement, setting, lighting, and sound intent directly.
 
 - **First frame:** describe only the motion, camera path, action development, and sound after the supplied opening state.
 - **Last frame:** describe the plausible path that converges on the supplied ending.
@@ -320,7 +324,7 @@ Primary guidance:
 - BytePlus Seedance 2.5 and 2.0 prompt guides: https://docs.byteplus.com/en/docs/ModelArk/2607689 and https://docs.byteplus.com/en/docs/ModelArk/2222480
 - HappyHorse launch and official prompting: https://www.alibabacloud.com/blog/alibaba-rolls-out-happyhorse-1-0-in-limited-beta_603068 and https://www.alibabacloud.com/help/en/model-studio/text-to-video-prompt
 - Kling 3.0 guides: https://kling.ai/quickstart/klingai-video-3-model-user-guide and https://kling.ai/quickstart/klingai-video-3-omni-model-user-guide
-- MiniMax H3: https://www.minimax.io/blog/minimax-h3, https://platform.minimax.io/docs/guides/video-generation, and https://huggingface.co/MiniMaxAI/MiniMax-H3/tree/main/docs
+- MiniMax H3 family: https://www.minimax.io/blog/minimax-h3, https://platform.minimax.io/docs/guides/video-generation, https://huggingface.co/MiniMaxAI/MiniMax-H3/tree/main/docs, and https://blog.fal.ai/introducing-h3-max-by-fal/
 - Gemini Omni: https://ai.google.dev/gemini-api/docs/omni
 - Lyria: https://ai.google.dev/gemini-api/docs/music-generation, https://deepmind.google/models/lyria/prompt-guide/, and https://cloud.google.com/blog/products/ai-machine-learning/ultimate-prompting-guide-for-lyria-3-pro
 - Seed Audio: https://seed.bytedance.com/en/blog/from-speech-to-audio-creation-introducing-the-seed-audio-1-0-audio-creation-model and https://docs.byteplus.com/en/docs/byteplusvoice/seedaudio-01

--- a/skills/model-routing/SKILL.md
+++ b/skills/model-routing/SKILL.md
@@ -1,13 +1,15 @@
 ---
 name: model-routing
 description: >
-  Internal Renoise model router and model-specific prompting guide. Selects the
-  best live image, video, or audio model for a task, then adapts the prompt to
-  that model. Use before estimating or generating Renoise media.
+  Choose the best Renoise image, video, or audio model and write prompts for it.
+  Always use before any Renoise generation estimate or task, and when the user
+  asks for the best model, model comparison, model routing, which model to use,
+  or “用哪个模型 / 模型选择”. Use alongside the active generation workflow;
+  this Skill does not execute tasks.
 user-invocable: false
 metadata:
   author: renoise
-  version: 0.1.1
+  version: 0.2.0
   category: media-generation
   tags: [model-routing, prompting, image, video, audio, portable]
 ---
@@ -27,6 +29,8 @@ Live model capabilities are authoritative for availability, defaults, input role
 5. Inspect the selected model's live guidance before writing the final prompt.
 6. Let the selected model's profile override generic prompt-craft advice when prompt structure, density, or reference wording conflicts.
 7. Never pass a role or parameter merely because this guide mentions a public model capability; the Renoise deployment may expose a narrower contract.
+
+Live availability alone is not a routing recommendation. Omit models that are fully dominated or lack a clear task advantage; an explicitly named model still follows rule 1.
 
 ## Routing Questions
 
@@ -52,14 +56,8 @@ Do not call a model “best” without naming the task it is best for.
 | Balanced Google workflow, extreme aspect ratios, several references, multilingual localization, or conversational iteration | `nano-banana-2` | Google-family workhorse balancing quality, latency, text, reference reasoning, and broad formats. |
 | Maximum Google-family world knowledge, brand consistency, localization, or reasoning-heavy composition | `nano-banana-pro` | Specialist for intricate professional assets and precise spatial relationships. |
 | Best aesthetic exploration, stylized art direction, editorial mood, or concept art | `mj-v8.2` | Current Midjourney default and strongest current aesthetic prior. |
-| Faster Midjourney iteration, small-detail retention, or a familiar V7-like look | `mj-v8.1` | Distinct speed/detail specialist when that version is live; V8.2 remains the normal aesthetic choice. |
-| Knowledge/reasoning-heavy visualization, many references, or 2K–4K Seedream work | `seedream-5-0-lite` | Strong intent inference and relational editing; Pro has the higher realism, structural-stability, and aesthetic ceiling. |
+| Seedream output above 2K or more than ten image references | `seedream-5-0-lite` | Its 3K–4K output and larger reference allowance are the remaining clear reasons to prefer it over Pro. |
 | xAI image request | `grok-image` for lower-cost iteration; `grok-image-quality` when higher quality justifies the added cost | Both support direct natural-language generation and editing through the live Renoise contract. |
-
-### Do not auto-select
-
-- `midjourney-v7`: keep for explicit requests, validated V7 compatibility, or its known treatment of bodies, objects, and references.
-- Older model versions remain valid specialists; version number alone is not a routing reason.
 
 ## Image Prompting Styles
 
@@ -154,10 +152,8 @@ Use a concise visual description, not a requirements document:
 | Short 720p generation, text rendering, or source-video edit within its narrow live contract | `gemini-omni-flash` | Strong short-form instruction following, multi-shot generation, and conversational editing. |
 | Exact first frame, last frame, frame interpolation, focused video references, 2K delivery, or reference audio paired with visual references | `hailuo-h3` | Strong endpoint control and structured multimodal audiovisual direction. |
 | Fastest, lowest-cost H3-family text-to-video or first/last-frame generation | `h3-max-turbo` | Rapid low-cost iteration when the live contract needs no generic image, video, or audio references; use full H3 instead when references or 2K are required. |
-| Human action, dialogue acting, lip sync, atmospheric commercial work, or concise cinematic multi-shot scenes | `happyhorse-1.0` | Strong motion, physical plausibility, visual depth, and synchronized dialogue/Foley/ambience through the inputs Renoise exposes. |
-| Reusable subjects/products, reference-driven series, identity/voice continuity, or custom multi-shot stories | `kling-3.0-omni` | Reference-first specialist with native audio, subject consistency, and explicit storyboard control. |
-| xAI text-to-video or one-image animation with native sound | `grok-video-1.5` | Current Renoise 1.5 contract is strongest when zero or one image is sufficient. |
-| xAI video needing several image references or the older Renoise Grok contract | `grok-video` | Multi-image and lower-duration niche currently exposed by Renoise. |
+| xAI one-image animation with native sound | `grok-video-1.5` | Current Renoise 1.5 contract requires exactly one input image. |
+| xAI text-to-video or video needing several image references | `grok-video` | The base contract retains text-only and multi-image modes that 1.5 does not expose. |
 
 ### Tier and version notes
 
@@ -226,30 +222,6 @@ Non-diegetic music: instrumentation, tempo, dynamics — or none.
 
 Specify camera **type + amplitude + speed** only when they matter. Keep dialogue exact, label speakers consistently, and separate in-scene sound from background score.
 
-### HappyHorse 1.0 — concise performance direction
-
-```text
-[subject] [specific action] in [setting], [lighting], [one camera cue].
-Dialogue in [language]: "..."
-Sound: foreground action, midground Foley, background ambience; no music if unwanted.
-```
-
-- Start with the entity, scene, and motion; add framing/lens, lighting, camera movement, style, and synchronized sound when they matter.
-- For image-to-video, emphasize motion and camera development rather than re-describing the still.
-- Use explicit shot structure for multiple beats and detailed cinematic direction when the scene benefits from it.
-
-### Kling 3.0 Omni — explicit storyboard
-
-```text
-Shot 1 (duration): framing, named subject, action, camera, light, sound.
-Shot 2 (duration): reaction or continuation, camera, exact dialogue and speaker.
-```
-
-- Define each reference's subject, product, motion, scene, or voice job before the shot plan.
-- Once appearance or voice is bound by a reference, focus the prompt on action, interaction, camera, and story progression.
-- Keep each shot to one readable action and one camera behavior.
-- Write dialogue after the associated action; use “then” or “immediately” for timing.
-
 ### Grok Imagine Video — animate the change
 
 For image-to-video, do not re-describe the static source:
@@ -312,7 +284,7 @@ Music cue and ending: ...
 
 # Research Basis
 
-Reviewed 2026-08-11. Rankings are directional and decay quickly; live capabilities and task-specific tests override them.
+Reviewed 2026-09-10. Rankings are directional and decay quickly; live capabilities and task-specific tests override them.
 
 Primary guidance:
 
@@ -322,8 +294,6 @@ Primary guidance:
 - ByteDance Seedream: https://seed.bytedance.com/en/blog/deeper-thinking-more-accurate-generation-introducing-seedream-5-0-lite and https://seed.bytedance.com/en/blog/beyond-generation-it-understands-design-introducing-seedream-5-0-pro
 - xAI Imagine image/video: https://docs.x.ai/developers/model-capabilities/imagine and https://docs.x.ai/developers/model-capabilities/video/generation
 - BytePlus Seedance 2.5 and 2.0 prompt guides: https://docs.byteplus.com/en/docs/ModelArk/2607689 and https://docs.byteplus.com/en/docs/ModelArk/2222480
-- HappyHorse launch and official prompting: https://www.alibabacloud.com/blog/alibaba-rolls-out-happyhorse-1-0-in-limited-beta_603068 and https://www.alibabacloud.com/help/en/model-studio/text-to-video-prompt
-- Kling 3.0 guides: https://kling.ai/quickstart/klingai-video-3-model-user-guide and https://kling.ai/quickstart/klingai-video-3-omni-model-user-guide
 - MiniMax H3 family: https://www.minimax.io/blog/minimax-h3, https://platform.minimax.io/docs/guides/video-generation, https://huggingface.co/MiniMaxAI/MiniMax-H3/tree/main/docs, and https://blog.fal.ai/introducing-h3-max-by-fal/
 - Gemini Omni: https://ai.google.dev/gemini-api/docs/omni
 - Lyria: https://ai.google.dev/gemini-api/docs/music-generation, https://deepmind.google/models/lyria/prompt-guide/, and https://cloud.google.com/blog/products/ai-machine-learning/ultimate-prompting-guide-for-lyria-3-pro

--- a/skills/model-routing/SKILL.md
+++ b/skills/model-routing/SKILL.md
@@ -37,7 +37,7 @@ Live availability alone is not a routing recommendation. Omit models that are fu
 Classify the request before selecting:
 
 - **Kind:** image, video, or audio.
-- **Operation:** create, edit, continue, interpolate, or animate a reference.
+- **Operation:** create, edit, continue, interpolate, animate a reference, or upscale.
 - **Priority:** final quality, strict instruction following, aesthetics, identity consistency, speed, or cost.
 - **Structure:** exact text/layout, one cinematic shot, multi-shot narrative, dialogue performance, music, or a complete audio scene.
 - **References:** none, one source image, several identity/style references, source video, endpoint frames, or voice/audio references.
@@ -151,9 +151,11 @@ Use a concise visual description, not a requirements document:
 | Lowest-cost/high-volume Seedance draft | `seedance-2.0-mini-byteplus` | Cost-performance tier for iteration and selection. |
 | Short 720p generation, text rendering, or source-video edit within its narrow live contract | `gemini-omni-flash` | Strong short-form instruction following, multi-shot generation, and conversational editing. |
 | Exact first frame, last frame, frame interpolation, focused video references, 2K delivery, or reference audio paired with visual references | `hailuo-h3` | Strong endpoint control and structured multimodal audiovisual direction. |
+| Fast H3-family text-to-video or first/last-frame generation where 768p is enough but quality matters more than minimum cost | `hailuo-h3-max` | Quality/speed middle tier between full H3 and Turbo; current arena results remain strong. |
 | Fastest, lowest-cost H3-family text-to-video or first/last-frame generation | `h3-max-turbo` | Rapid low-cost iteration when the live contract needs no generic image, video, or audio references; use full H3 instead when references or 2K are required. |
 | xAI one-image animation with native sound | `grok-video-1.5` | Current Renoise 1.5 contract requires exactly one input image. |
 | xAI text-to-video or video needing several image references | `grok-video` | The base contract retains text-only and multi-image modes that 1.5 does not expose. |
+| Upscale an existing video without changing its content | `upscale-video-topaz-starlight-2.5` | Dedicated restoration/upscaling model; use a generation or editing model when objects, motion, timing, or style should change. |
 
 ### Tier and version notes
 
@@ -236,6 +238,10 @@ Sound: specific dialogue/SFX/ambience; no music if unwanted.
 - Assign every live reference a clear visual or motion job.
 - Request dialogue, effects, ambience, or music explicitly when native audio matters.
 
+### Topaz Starlight — no creative prompt
+
+Upscaling is not regeneration. Supply only the source video and settings required by the live capability; do not add a creative prompt or unrelated media inputs. If the user wants content changed, route to a video editing model instead.
+
 # Audio Routing
 
 | Task | Prefer | Why |
@@ -295,6 +301,7 @@ Primary guidance:
 - xAI Imagine image/video: https://docs.x.ai/developers/model-capabilities/imagine and https://docs.x.ai/developers/model-capabilities/video/generation
 - BytePlus Seedance 2.5 and 2.0 prompt guides: https://docs.byteplus.com/en/docs/ModelArk/2607689 and https://docs.byteplus.com/en/docs/ModelArk/2222480
 - MiniMax H3 family: https://www.minimax.io/blog/minimax-h3, https://platform.minimax.io/docs/guides/video-generation, https://huggingface.co/MiniMaxAI/MiniMax-H3/tree/main/docs, and https://blog.fal.ai/introducing-h3-max-by-fal/
+- Topaz Starlight Precise 2.5: https://developer.topazlabs.com/video-models/starlight/starlight-precise-2.5
 - Gemini Omni: https://ai.google.dev/gemini-api/docs/omni
 - Lyria: https://ai.google.dev/gemini-api/docs/music-generation, https://deepmind.google/models/lyria/prompt-guide/, and https://cloud.google.com/blog/products/ai-machine-learning/ultimate-prompting-guide-for-lyria-3-pro
 - Seed Audio: https://seed.bytedance.com/en/blog/from-speech-to-audio-creation-introducing-the-seed-audio-1-0-audio-creation-model and https://docs.byteplus.com/en/docs/byteplusvoice/seedaudio-01

--- a/tests/single-source.test.mjs
+++ b/tests/single-source.test.mjs
@@ -113,7 +113,8 @@ test('model routing keeps only useful specialists without replacing capabilities
     'nano-banana-2', 'nano-banana-2-lite', 'nano-banana-pro',
     'mj-v8.2', 'gpt-image-2', 'seedream-5-0-lite', 'seedream-5-0-pro',
     'lyria-clip', 'seed-audio-1.0', 'grok-image', 'grok-image-quality',
-    'grok-video', 'grok-video-1.5', 'gemini-omni-flash', 'hailuo-h3', 'h3-max-turbo',
+    'grok-video', 'grok-video-1.5', 'gemini-omni-flash', 'hailuo-h3', 'hailuo-h3-max', 'h3-max-turbo',
+    'upscale-video-topaz-starlight-2.5',
   ]) assert.ok(routing.includes(model), `${model} routing missing`);
   for (const obsolete of ['midjourney-v7', 'mj-v8.1', 'happyhorse-1.0', 'kling-3.0-omni']) {
     assert.ok(!routing.includes(obsolete), `${obsolete} should not be routed`);

--- a/tests/single-source.test.mjs
+++ b/tests/single-source.test.mjs
@@ -106,18 +106,19 @@ test('local renoise-cli remains the only CLI execution skill', () => {
   }
 });
 
-test('model routing covers every live family without replacing capabilities', () => {
+test('model routing keeps only useful specialists without replacing capabilities', () => {
   const routing = readFileSync('skills/model-routing/SKILL.md', 'utf8');
   for (const model of [
     'seedance-2.5-byteplus', 'seedance-2.0-byteplus', 'seedance-2.0-fast-byteplus', 'seedance-2.0-mini-byteplus',
     'nano-banana-2', 'nano-banana-2-lite', 'nano-banana-pro',
-    'midjourney-v7', 'mj-v8.1', 'mj-v8.2', 'gpt-image-2',
-    'seedream-5-0-lite', 'seedream-5-0-pro', 'happyhorse-1.0', 'kling-3.0-omni',
+    'mj-v8.2', 'gpt-image-2', 'seedream-5-0-lite', 'seedream-5-0-pro',
     'lyria-clip', 'seed-audio-1.0', 'grok-image', 'grok-image-quality',
     'grok-video', 'grok-video-1.5', 'gemini-omni-flash', 'hailuo-h3', 'h3-max-turbo',
   ]) assert.ok(routing.includes(model), `${model} routing missing`);
+  for (const obsolete of ['midjourney-v7', 'mj-v8.1', 'happyhorse-1.0', 'kling-3.0-omni']) {
+    assert.ok(!routing.includes(obsolete), `${obsolete} should not be routed`);
+  }
   assert.match(routing, /Live model capabilities are authoritative/);
-  assert.match(routing, /Do not auto-select/);
 });
 
 test('prompt examples use canonical material ID tokens', () => {

--- a/tests/single-source.test.mjs
+++ b/tests/single-source.test.mjs
@@ -114,7 +114,7 @@ test('model routing covers every live family without replacing capabilities', ()
     'midjourney-v7', 'mj-v8.1', 'mj-v8.2', 'gpt-image-2',
     'seedream-5-0-lite', 'seedream-5-0-pro', 'happyhorse-1.0', 'kling-3.0-omni',
     'lyria-clip', 'seed-audio-1.0', 'grok-image', 'grok-image-quality',
-    'grok-video', 'grok-video-1.5', 'gemini-omni-flash', 'hailuo-h3',
+    'grok-video', 'grok-video-1.5', 'gemini-omni-flash', 'hailuo-h3', 'h3-max-turbo',
   ]) assert.ok(routing.includes(model), `${model} routing missing`);
   assert.match(routing, /Live model capabilities are authoritative/);
   assert.match(routing, /Do not auto-select/);


### PR DESCRIPTION
## Summary

- remove superseded or low-value automatic model routes
- add distinct H3 Max, H3 Max Turbo, and Topaz Starlight routing
- tighten Seedream and Grok niches and improve internal skill discovery

Supersedes #43.

## Test

- `npm test`