### PR TITLE
feat(skills): use source video for fission

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
   "plugins": [
     {
       "name": "renoise",
-      "version": "1.8.0",
+      "version": "1.8.1",
       "source": "./",
       "description": "AI video production skills — creative direction, generation, editing, and e-commerce content"
     }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "renoise",
   "description": "AI video production skills — creative direction, generation, editing, and e-commerce content",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "author": {
     "name": "Renoise"
   },

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "renoise",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "description": "AI video production skills — creative direction, generation, editing, and e-commerce content",
   "author": {
     "name": "Renoise"

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "renoise",
   "name": "Renoise",
   "description": "AI video production skills — creative direction, generation, editing, and e-commerce content",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "configSchema": {
     "type": "object",
     "additionalProperties": false,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@renoise/plugin",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "license": "Apache-2.0",
   "type": "module",
   "description": "AI video production skills — creative direction, generation, editing, and e-commerce content",

--- a/skills/manifest.json
+++ b/skills/manifest.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "pluginVersion": "1.8.0",
+  "pluginVersion": "1.8.1",
   "skills": [
     {
       "id": "director",

--- a/skills/video-fission/SKILL.md
+++ b/skills/video-fission/SKILL.md
@@ -7,7 +7,7 @@ description: >
   source first, then confirm what should vary before proposing any generation.
 metadata:
   author: renoise
-  version: 0.1.0
+  version: 0.2.0
   category: video-production
   tags: [video, fission, variants, experimentation, portable]
 ---
@@ -34,7 +34,6 @@ Live model capabilities are authoritative for availability, roles, role combinat
 Report the analysis in the user's language, including:
 
 - subject, setting, actions, camera, composition, lighting, style, pacing/edit structure, duration, aspect ratio, and audio/dialogue;
-- the strongest anchor-frame timestamp and why it represents the clip;
 - dimensions that appear fixed and plausible dimensions to vary;
 - uncertain or inferred details as warnings.
 
@@ -46,19 +45,15 @@ Then ask one focused question:
 
 Offer only source-relevant directions, such as action/motion, camera treatment, pacing, atmosphere/lighting, performance, or transformation. Do not preselect a direction for the user.
 
-## 2. Select the Shared Anchor Frame
+## 2. Use the Source Video Directly
 
 This workflow has one generation path:
 
-1. Select MiniMax H3 Max (`hailuo-h3-max`) only if the live capability advertises `first_frame`.
-2. Choose the analyzed source timestamp whose visual state best anchors the requested experiment.
-3. Use that one extracted image as every variant's `first_frame`; prompt only what happens after it.
+1. Select MiniMax H3 Max (`hailuo-h3-max`) only if the live capability advertises `reference_video`.
+2. Use the exact owner-authorized source as every variant's sole `reference_video` input.
+3. Refer to that source as `Video 1` in every generation prompt.
 
-The timestamp may point anywhere in the source video. "Anchor frame" means the representative visual frame chosen from the analysis, not a codec keyframe. The agent chooses the timestamp; FFmpeg only extracts that exact frame after approval.
-
-**H3 Max input rule:** H3 Max does not accept generic `reference_image` or `reference_video` inputs. Its supported visual conditioning inputs are `first_frame` and `last_frame`; this workflow uses `first_frame`. Never relabel the source video or anchor as a generic reference for H3 Max.
-
-The agent does not extract the anchor in advance. On approval, `create_video_fission` prepares the browser-extracted frame and attaches it to the run. If H3 Max first-frame generation is not live, stop and explain that this workflow is currently unavailable; do not invent another mode or silently route to another model.
+Do not extract or upload a frame, and do not replace the source with a `first_frame`. Respect the live capability's reference-video duration and count limits. If H3 Max reference-video generation is not live or the source is outside those limits, stop and explain that this workflow is currently unavailable; do not invent another mode or silently route to another model.
 
 ## 3. Design the Experiment
 
@@ -72,7 +67,7 @@ Rules:
 
 - Use one axis by default and never more than two.
 - Give every variant a genuinely distinct, testable hypothesis; do not use cosmetic synonyms.
-- Lock all unselected dimensions across every variant, including model, source/anchor, subject identity, composition, duration, ratio, resolution, audio mode, dialogue, and output controls unless one is the confirmed axis.
+- Lock all unselected dimensions across every variant, including model, source video, subject identity, composition, duration, ratio, resolution, audio mode, dialogue, and output controls unless one is the confirmed axis.
 - Keep the same prompt skeleton and change only the clauses that implement the confirmed axis values.
 - If two axes are used, choose intentional combinations; do not create an unrequested Cartesian product.
 - Derive every parameter and material role from the selected model's live capability.
@@ -85,13 +80,13 @@ If any variant contains dialogue, voiceover, or narration, confirm the spoken la
 
 ## 4. Submit Once
 
-After the direction, count, anchor timestamp, hypotheses, prompts, and any spoken language are confirmed, call `create_video_fission` once with the complete variant plan. If the authorized source came from a Canvas node, preserve that exact node ID in the operation so every output can project with a source edge.
+After the direction, count, hypotheses, prompts, and any spoken language are confirmed, call `create_video_fission` once with the complete variant plan. Pass the source aspect ratio, or the closest ratio supported by H3 Max. If the authorized source came from a Canvas node, preserve that exact node ID in the operation so every output can project with a source edge.
 
 The host operation must:
 
 - emit one **Run all** confirmation card, not one card per variant;
 - show a live estimate for every variant and the total;
-- prepare the browser-extracted anchor frame only after approval;
+- submit the source video directly as every task's `reference_video`;
 - create no tasks if the user declines;
 - return and track the resulting task IDs without repeating paid creation.
 

--- a/tests/single-source.test.mjs
+++ b/tests/single-source.test.mjs
@@ -262,14 +262,15 @@ test('video fission analyzes first and submits one controlled batch', () => {
   assert.match(fission, /Four is not a hard cap/i);
   assert.match(fission, /one axis by default and never more than two/i);
   assert.match(fission, /distinct, testable hypothesis/i);
-  assert.match(fission, /H3 Max does not accept generic `reference_image` or `reference_video`/);
-  assert.match(fission, /`first_frame` and `last_frame`/);
+  assert.match(fission, /sole `reference_video` input/);
+  assert.match(fission, /Refer to that source as `Video 1`/);
+  assert.match(fission, /Do not extract or upload a frame/);
   assert.match(fission, /one generation path/i);
   assert.match(fission, /do not invent another mode/i);
   assert.match(fission, /call `create_video_fission` once/i);
   assert.match(fission, /one \*\*Run all\*\* confirmation card/i);
   assert.match(fission, /estimate for every variant and the total/i);
-  assert.match(fission, /browser-extracted anchor frame only after approval/i);
+  assert.match(fission, /submit the source video directly as every task's `reference_video`/i);
   assert.match(fission, /Never replace this operation with a loop of `create_task` calls/i);
   assert.match(fission, /confirm the spoken language/i);
   assert.match(director, /explicit video fission or multiple controlled variants/i);


### PR DESCRIPTION
## Summary
- update video-fission to submit the source video directly as `reference_video`
- remove anchor-frame extraction guidance
- bump plugin metadata to 1.8.1

## Test
- `npm test`