### PR TITLE
fix(skills): delegate execution details to active hosts

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
   "plugins": [
     {
       "name": "renoise",
-      "version": "1.8.1",
+      "version": "1.8.2",
       "source": "./",
       "description": "AI video production skills — creative direction, generation, editing, and e-commerce content"
     }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "renoise",
   "description": "AI video production skills — creative direction, generation, editing, and e-commerce content",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "author": {
     "name": "Renoise"
   },

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "renoise",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "description": "AI video production skills — creative direction, generation, editing, and e-commerce content",
   "author": {
     "name": "Renoise"

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "renoise",
   "name": "Renoise",
   "description": "AI video production skills — creative direction, generation, editing, and e-commerce content",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "configSchema": {
     "type": "object",
     "additionalProperties": false,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@renoise/plugin",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "license": "Apache-2.0",
   "type": "module",
   "description": "AI video production skills — creative direction, generation, editing, and e-commerce content",

--- a/skills/director/SKILL.md
+++ b/skills/director/SKILL.md
@@ -15,7 +15,7 @@ description: >
   of existing footage.
 metadata:
   author: renoise
-  version: 0.7.0
+  version: 0.7.1
   category: video-production
   tags: [director, creative, video, product, ecommerce, short-film, narrative, story, portable]
 ---
@@ -49,14 +49,14 @@ Use only Renoise capabilities exposed by the current host. Do not guess commands
 
 - Platform URL: **https://www.renoise.ai** (never renoise.com).
 - **Models and limits are live data.** Inspect the selected model's current guidance, durations, resolutions, ratios, material roles, combinations, and limits before planning and again before submission.
-- **Duration is a hard gate.** Follow the user's preference and advertised durations. If total or per-segment duration is missing, confirm it before writing prompts; choose segment count only afterward.
+- **Duration must be resolved.** Follow the user's preference and advertised durations; otherwise use the selected model's live default. Clarify only when materially different durations would change the stated goal and no safe default exists; choose segment count afterward.
 - One mood per segment; do not combine contradictory tone or color instructions.
 - Use only references the host authorizes: conversation attachments, materials, task results, or other exposed sources. If the host cannot register one for generation, explain the limitation rather than requesting host filesystem details.
-- Before spending credits, request live estimates for every planned generation, include anchors/audio/enhancement, compare the total with the live balance, and wait for the workflow's required approval.
+- Before execution, hand the complete plan and actual parameters for every generation, including anchors/audio/enhancement, to the active host workflow. The host owns tool or command names, estimates, balance checks, approvals, idempotency, and task tracking.
 
 ### Spoken-language Hard Rule
 
-If any segment contains dialogue, voiceover, or narration, confirm the spoken language before writing prompts. Then:
+If any segment contains dialogue, voiceover, or narration, use the explicitly requested or safely inferable spoken language; clarify only when ambiguous. Then:
 
 1. Keep every spoken line verbatim in that language; translating it changes the generated voice.
 2. Keep a dialogue-dense segment's whole prompt in the spoken language so surrounding English does not pull speech toward English.
@@ -64,11 +64,11 @@ If any segment contains dialogue, voiceover, or narration, confirm the spoken la
 
 No workflow or rich brief waives this gate.
 
-### Approval and Credit Safety
+### Execution Safety
 
-- **Single paid clip:** present the full prompt, model parameters, materials, live estimate, and balance; wait for explicit approval.
-- **Multi-shot narrative:** follow Gate 1 Story, then Gate 2 Consistency Manifest. Spend no video-generation credits until both are confirmed; paid anchor images inside Gate 2 need their own prompt-and-cost approval first.
-- **Reference remake:** route to `video-remake`; it owns the slot-plan and final-generation gates.
+- **Single clip:** hand the full prompt, model parameters, and materials to the active host execution workflow.
+- **Multi-shot narrative:** follow Gate 1 Story, then Gate 2 Consistency Manifest. Resolve both creative choices before handing paid anchors or video segments to the host.
+- **Reference remake:** route to `video-remake`; it owns the slot plan and final-generation handoff.
 - Record every returned task ID immediately. After interruption or timeout, resume that task; never blindly repeat paid creation.
 
 ### Continuity
@@ -78,7 +78,7 @@ For multi-shot work:
 - Any character appearing in two or more segments must reuse one user-supplied or approved generated design-sheet material. A text-only description plus a drift warning is not acceptable.
 - Lock recurring props, wardrobe states, and locations. Plot-driven changes require an explicit transformation shot.
 - Freeze one Style Bible (`art style + camera language + color grade + NEGATIVE line`) and prepend it verbatim to every segment.
-- Confirm a Transition Table before generation. Intermediate segments end on a motion/composition hook; only the final segment may settle on `frame holds steady`.
+- Resolve and disclose a Transition Table before generation. Intermediate segments end on a motion/composition hook; only the final segment may settle on `frame holds steady`.
 - Choose image, frame, and video continuity only from live capabilities. Reuse a completed result only through an advertised video-reference capability.
 
 ## Moderation

--- a/skills/director/commercial/INDEX.md
+++ b/skills/director/commercial/INDEX.md
@@ -53,7 +53,7 @@ Scenario D performs its documented reference registration before prompt writing.
 
 ## Phase 2 — Construct the Prompt
 
-Draft the approval preview in the user's language. A non-dialogue final generation prompt may be translated to concise professional English after approval. Any spoken line stays verbatim in the confirmed spoken language; dialogue-dense prompts stay entirely in that language.
+Draft the generation arguments in the user's language. A non-dialogue final generation prompt may be translated to concise professional English before submission. Any spoken line stays verbatim in the resolved spoken language; dialogue-dense prompts stay entirely in that language.
 
 Required:
 
@@ -80,9 +80,9 @@ Never compress a multi-step physical process into one sentence. Give each demons
 2. One fingertip gently taps the center; it is not spread yet.
 3. Slow outward circles spread it halfway; the unblended edge stays visible.
 
-## Phase 3 — Approval Preview
+## Phase 3 — Execution Handoff
 
-Present the entire preview in the user's language and wait for explicit approval:
+Hand the complete arguments below to the active host execution workflow. Do not assume a particular tool, command, card, or approval interface:
 
 ```text
 --- Prompt Preview ---
@@ -108,7 +108,7 @@ Scenario C uses its storyboard preview.
 
 - Reinspect the selected model immediately before submission.
 - Translate only non-speaking prompts when useful; never translate confirmed spoken lines.
-- Submit through the host's approval-controlled capability and record every returned task ID.
+- Execute through the active host workflow and record every returned task identifier.
 - Reuse shared materials for multi-segment work and choose continuity only from advertised roles.
 - Return result links, task IDs, cover images when available, generation time, and warnings.
 - On revision, preserve approved references/results and adjust only the rejected dimension or segment.

--- a/skills/director/commercial/scenario-c-tvc.md
+++ b/skills/director/commercial/scenario-c-tvc.md
@@ -13,7 +13,7 @@
 | **Subject** | Person + product exist together as storytelling elements — neither dominates; anchor both with `@` references |
 | **Selling-Point Action** | Replace feature callouts with cinematic micro-moments: product interacting with environment (boot crushing wet grass, jacket catching wind), body language conveying effort or freedom |
 | **Scene & Tone** | Rich, specific environments — anchor with the scene's `@material:{id}` token; describe light quality (golden morning haze, blue-hour ridge glow), atmosphere, and how the environment feels physically |
-| **Camera Language** | Follow the user's shot ideas if specified. If unspecified, propose a shot plan and wait for confirmation before writing prompts. |
+| **Camera Language** | Follow the user's shot ideas if specified. If unspecified, use and disclose a coherent shot plan before writing prompts. |
 | **Audio** | No dialogue — music-driven. Write a **unified audio direction** spanning the entire video, with per-shot accents. |
 | **Post-Production** | Person consistency across all shots; end frame reserved for slogan/logo (fade to black + centered text); no jump cuts |
 
@@ -32,7 +32,7 @@ Generate as **one single task**. Write all visual stages into one prompt plus a 
 
 **How to determine the shot plan:**
 - User has clear shots → use them directly and polish
-- Brief is vague → propose a shot plan and wait for user confirmation before writing the prompt
+- Brief is vague → use the default arc below, adapt it to the brief, and disclose the shot plan before writing the prompt
 
 **Default arc when unspecified** (adjust freely):
 ```

--- a/skills/director/commercial/scenario-d-ugc.md
+++ b/skills/director/commercial/scenario-d-ugc.md
@@ -11,7 +11,7 @@
 Register all host-authorized assets **before writing the prompt** so material IDs are known during construction.
 
 1. Register the presenter once and reuse the **same material ID** through an image-reference role advertised by the selected model.
-2. If the user did not provide a presenter, clarify the desired person, inspect a live image model, present the portrait prompt and estimate, wait for approval, generate it through the host, then show and register the approved result once.
+2. If the user did not provide a presenter, clarify the desired person, inspect a live image model, and hand the portrait prompt to the active host execution workflow. Then show and register the accepted result once.
 3. Register each approved product image once and assign only a role advertised by the selected video model.
 4. Record every material ID and full server filename, then proceed to Phase 2.
 

--- a/skills/director/references/prompt-craft.md
+++ b/skills/director/references/prompt-craft.md
@@ -366,7 +366,7 @@ Attaching a material without mapping it in the prompt may leave the model unsure
 
 ## Dialogue Format
 
-**First, the Spoken-language Hard Rule (see SKILL.md):** any segment with dialogue / voiceover / narration requires you to **confirm the spoken language with the user before writing prompts**, and to write the dialogue line **verbatim in that confirmed language** — the model speaks whatever language the line text is in, so translating the line changes the voice. For a dialogue-dense segment, keep the whole segment prompt in the spoken language so a large English block does not drag the speech toward English. Label the spoken language of each dialogue segment in the Gate 2 preview ("S4 口播：中文").
+**First, the Spoken-language Hard Rule (see SKILL.md):** any segment with dialogue / voiceover / narration requires an explicitly requested or safely inferable spoken language; clarify only when ambiguous. Write the dialogue line **verbatim in that language** — the model speaks whatever language the line text is in, so translating the line changes the voice. For a dialogue-dense segment, keep the whole segment prompt in the spoken language so a large English block does not drag the speech toward English. Label the spoken language of each dialogue segment in the Gate 2 preview ("S4 口播：中文").
 
 When a character speaks, write the line in the confirmed language and mark the mouth as visible:
 

--- a/skills/director/references/visual-dev.md
+++ b/skills/director/references/visual-dev.md
@@ -15,7 +15,7 @@ Do not maintain a model matrix in this Skill.
 
 ## Character Design Sheet
 
-A character appearing in more than one segment needs one approved visual anchor. Generate it once through the host's approval-controlled generation flow, show it to the user, register it as a reusable material, and reuse the same material ID through an image-reference role supported by the selected video model.
+A character appearing in more than one segment needs one approved visual anchor. Generate it once through the active host execution workflow, show it to the user, register it as a reusable material, and reuse the same material ID through an image-reference role supported by the selected video model.
 
 Prompt template:
 
@@ -36,9 +36,8 @@ Consistent appearance across every panel. No labels or background elements.
 Before generating:
 
 - inspect the selected image model;
-- present prompt, parameters, and estimate;
-- wait for approval;
-- record the returned task ID;
+- hand the prompt and parameters to the active host execution workflow;
+- record any task identifier returned by the host;
 - show the result for approval;
 - register the approved result once;
 - inspect the selected video model before assigning its role.

--- a/skills/director/workflows/narrative.md
+++ b/skills/director/workflows/narrative.md
@@ -23,13 +23,12 @@ Select and inspect the video model before deciding whether this is one clip or m
 Use when the requested duration fits one advertised model duration.
 
 1. Write one model-appropriate, high-density prompt using `model-routing` and `prompt-craft.md`.
-2. Present the complete prompt, references, model parameters, live estimate, and balance in the user's language.
-3. Wait for explicit approval.
-4. Submit once through the host's approval-controlled generation capability and record the returned task ID.
+2. Hand the complete prompt, references, and model parameters to the active host execution workflow.
+3. Record any task identifier returned by the host.
 
 ## Multi-Clip: Two Gates
 
-Spend no video-generation credits until the user confirms both gates in order. Paid anchor images are the only exception and require explicit prompt-and-cost approval during Gate 2:
+Resolve both creative gates in order before handing video generation to the host. Paid anchor images may execute during Gate 2 through the active host workflow:
 
 ```text
 brief → Gate 1 Story → approval → Gate 2 anchor plan/cost → anchor approval → final manifest/prompts → approval → generate video → QC → assemble
@@ -53,8 +52,8 @@ Rules:
 
 After the story is approved:
 
-1. Present every needed character/location anchor prompt, selected image model, and live cost; wait for explicit approval before paid anchor generation.
-2. Generate only approved anchors and let the user approve or replace each result.
+1. Hand every needed character/location anchor prompt and selected image model to the active host execution workflow.
+2. Generate only accepted anchors and let the user approve or replace each result.
 3. Draft all segment prompts and present the final manifest below in one editable block; wait for approval before any video task.
 
 | Item | Lock |
@@ -89,7 +88,7 @@ Prompt construction:
 
 Reinspect live model capabilities immediately before submission. Reuse stable materials through advertised roles; use a tail frame only through an advertised image/frame role, and reuse completed video only through a compatible video-reference capability.
 
-Sequential dependencies run serially; independent segments may run in parallel. Submit only through the host's approval-controlled capability, record every task ID, and resume those IDs after interruption.
+Run read-only preparation in parallel when independent. Hand generation to the active host workflow, which owns submission concurrency, approvals, idempotency, task identifiers, and interruption recovery.
 
 ## QC and Assembly
 
@@ -101,9 +100,9 @@ Before final assembly, compare every segment and cut against the confirmed manif
 - spoken language is correct;
 - no failed physical action or unusable frame.
 
-Report the result and regenerate only failed segments after confirmation. Assemble only when the host exposes media editing; otherwise return ordered clips plus the transition plan.
+Report the result and hand only failed segments back to the host for regeneration. Assemble only when the host exposes media editing; otherwise return ordered clips plus the transition plan.
 
-If soundtrack or enhancement is requested, choose a live model by task fit and guidance, estimate it, obtain approval, and use only advertised inputs and outputs.
+If soundtrack or enhancement is requested, choose a live model by task fit and guidance, then hand only advertised inputs and outputs to the active host workflow.
 
 ## Creative Recovery
 

--- a/skills/manifest.json
+++ b/skills/manifest.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "pluginVersion": "1.8.1",
+  "pluginVersion": "1.8.2",
   "skills": [
     {
       "id": "director",

--- a/skills/renoise-cli/SKILL.md
+++ b/skills/renoise-cli/SKILL.md
@@ -16,7 +16,7 @@ allowed-tools: Bash, Read, Write, Glob
 user-invocable: false
 metadata:
   author: renoise
-  version: 0.8.0
+  version: 0.8.1
   category: video-production
   tags: [general, video-generation, image-generation, material-pool]
 ---
@@ -133,7 +133,7 @@ Before spending credits:
 2. Multiply `estimatedCredit` by the planned number of generations.
 3. Add character-sheet, upscale, audio, and retry costs when applicable.
 4. Compare with `renoise account status --json`.
-5. Tell the user the estimate and wait for approval when the director workflow requires it.
+5. Tell the user the per-task and total estimate, then wait for one approval immediately before executing the disclosed paid batch. Do not ask for an earlier duplicate approval.
 
 Never quote static prices.
 

--- a/skills/storyboard-sheet/SKILL.md
+++ b/skills/storyboard-sheet/SKILL.md
@@ -6,7 +6,7 @@ description: >
   plans. Supports episode-level review sheets and shot-by-shot planning.
 metadata:
   author: renoise
-  version: 0.4.0
+  version: 0.4.1
   category: video-production
   tags: [storyboard, short-drama, adaptation, image-generation, video-generation, portable]
 ---
@@ -15,7 +15,7 @@ metadata:
 
 Turn source text into usable visual planning for short drama and AI video generation. Do not paste raw novel/script text into image prompts; first adapt it into visual beats.
 
-Use only capabilities exposed by the current host. Planning works without generation capability. If the user asks to generate outputs, query live capabilities and use the host's approval-controlled generation flow. If generation is unavailable, return the complete plan and prompts in the conversation; never guess commands or require host filesystem access.
+Use only capabilities exposed by the current host. Planning works without generation capability. If the user asks to generate outputs, query live capabilities and hand the complete plan to the active host execution workflow. If generation is unavailable, return the complete plan and prompts in the conversation; never guess commands or require host filesystem access.
 
 ```text
 source → adaptation bible → episode beats → shot list/sheet plan → references → prompts → optional generation → QA → targeted rerun
@@ -119,9 +119,8 @@ Before optional generation, read `../model-routing/SKILL.md`, then:
 1. Query live image-model capabilities.
 2. Preserve a user-selected model; otherwise choose the best available specialist for the shot/sheet task and use the advertised default only as fallback.
 3. Apply that model's prompting profile and use only advertised ratio, resolution, duration, material roles, and limits.
-4. Present the prompt, references, parameters, and estimate.
-5. Wait for explicit approval.
-6. Record the returned task ID before waiting or polling.
+4. Hand the complete prompt, references, and parameters to the active host execution workflow.
+5. Record any task identifier returned by the host before waiting or polling.
 
 ## 4. Output Templates
 

--- a/skills/video-fission/SKILL.md
+++ b/skills/video-fission/SKILL.md
@@ -4,10 +4,10 @@ description: >
   Create controlled variants from one owner-authorized source video. Use when
   the user explicitly asks for video fission, multiple video variants,
   controlled variations, or several hypotheses from the same clip. Analyze the
-  source first, then confirm what should vary before proposing any generation.
+  source first, then resolve what should vary before proposing any generation.
 metadata:
   author: renoise
-  version: 0.2.0
+  version: 0.2.1
   category: video-production
   tags: [video, fission, variants, experimentation, portable]
 ---
@@ -24,10 +24,10 @@ Live model capabilities are authoritative for availability, roles, role combinat
 
 ## Hard Gates
 
-1. **Analyze before asking for a direction.** Once the source is available, use the host's video-analysis capability before asking what to vary. If analysis is unavailable or fails, stop. Analysis creates no generation task.
-2. **Confirm the fission direction.** After showing the analysis, ask which one experimental axis to vary; allow a second axis only when the user explicitly needs it. Even if the initial request names a direction, restate it after analysis and get confirmation. Create no task before this confirmation.
-3. **Confirm the count.** Default to **4 outputs** when no count is supplied. Four is not a hard cap: accept another reasonable count of at least two, constrained only by live service limits, the total estimate, and the user's budget.
-4. **Use one batch operation.** Submit the approved experiment exactly once through `create_video_fission`. Do not fan it out into multiple `create_task` calls.
+1. **Analyze before resolving the direction.** Once the source is available, use the host's video-analysis capability before finalizing what to vary. If analysis is unavailable or fails, stop. Analysis creates no generation task.
+2. **Clarify only when blocked.** If the initial request already names a usable, safe experimental axis, use it after analysis without restating it for text confirmation. Ask one focused question only when the axis is absent, unsafe, or ambiguous; allow a second axis only when the user explicitly needs it.
+3. **Default the count.** Use **4 outputs** when no count is supplied; do not ask merely to confirm that default. Four is not a hard cap: accept another reasonable count of at least two, constrained only by live service limits, the total estimate, and the user's budget.
+4. **Use one logical batch.** Hand the complete disclosed experiment to the active host execution workflow. Use a native batch primitive when the host exposes one; otherwise follow its documented ordered execution path. Do not invent tool names or execution interfaces.
 
 ## 1. Analyze the Source
 
@@ -37,13 +37,11 @@ Report the analysis in the user's language, including:
 - dimensions that appear fixed and plausible dimensions to vary;
 - uncertain or inferred details as warnings.
 
-Do not ask the user to choose a direction until this report exists.
-
-Then ask one focused question:
+Do not resolve an unstated direction until this report exists. If the request already supplies a usable axis, disclose how the analysis maps to it and proceed. Otherwise ask one focused question:
 
 > Which direction should the variants explore? I recommend one axis from this clip's analysis; we can use at most two. The default is 4 outputs, or name another reasonable count.
 
-Offer only source-relevant directions, such as action/motion, camera treatment, pacing, atmosphere/lighting, performance, or transformation. Do not preselect a direction for the user.
+Offer only source-relevant directions, such as action/motion, camera treatment, pacing, atmosphere/lighting, performance, or transformation. Do not preselect an absent direction for the user.
 
 ## 2. Use the Source Video Directly
 
@@ -67,27 +65,27 @@ Rules:
 
 - Use one axis by default and never more than two.
 - Give every variant a genuinely distinct, testable hypothesis; do not use cosmetic synonyms.
-- Lock all unselected dimensions across every variant, including model, source video, subject identity, composition, duration, ratio, resolution, audio mode, dialogue, and output controls unless one is the confirmed axis.
-- Keep the same prompt skeleton and change only the clauses that implement the confirmed axis values.
+- Lock all unselected dimensions across every variant, including model, source video, subject identity, composition, duration, ratio, resolution, audio mode, dialogue, and output controls unless one is the selected axis.
+- Keep the same prompt skeleton and change only the clauses that implement the selected axis values.
 - If two axes are used, choose intentional combinations; do not create an unrequested Cartesian product.
 - Derive every parameter and material role from the selected model's live capability.
 
 ## Dialogue and Language
 
-Use the user's language for analysis, questions, matrices, confirmation text, and results. Prompts are English by default only when they contain no speech.
+Use the user's language for analysis, questions, matrices, plan text, and results. Prompts are English by default only when they contain no speech.
 
-If any variant contains dialogue, voiceover, or narration, confirm the spoken language before writing final prompts. Keep every spoken line verbatim in that confirmed language; never translate it. For dialogue-dense variants, keep the whole prompt in the spoken language. Unless dialogue is the confirmed axis, lock its text, speaker, delivery, and spoken language across all variants.
+If any variant contains dialogue, voiceover, or narration, use the explicitly requested or safely inferable spoken language; clarify it only when ambiguous. Keep every spoken line verbatim in that language; never translate it. For dialogue-dense variants, keep the whole prompt in the spoken language. Unless dialogue is the selected axis, lock its text, speaker, delivery, and spoken language across all variants.
 
-## 4. Submit Once
+## 4. Hand Off One Logical Batch
 
-After the direction, count, hypotheses, prompts, and any spoken language are confirmed, call `create_video_fission` once with the complete variant plan. Pass the source aspect ratio, or the closest ratio supported by H3 Max. If the authorized source came from a Canvas node, preserve that exact node ID in the operation so every output can project with a source edge.
+After the direction, count, hypotheses, prompts, and any spoken language are resolved, hand the complete variant plan to the active host execution workflow. Pass the source aspect ratio, or the closest ratio supported by H3 Max. Preserve any source provenance handle exposed by the host so outputs remain linked to their source where supported.
 
-The host operation must:
+The execution handoff must:
 
-- emit one **Run all** confirmation card, not one card per variant;
-- show a live estimate for every variant and the total;
+- keep the whole experiment reviewable as one disclosed plan;
+- provide the actual parameters needed for per-variant and total estimation;
 - submit the source video directly as every task's `reference_video`;
-- create no tasks if the user declines;
-- return and track the resulting task IDs without repeating paid creation.
+- follow the host's approval, concurrency, idempotency, and task-tracking rules;
+- preserve variant order and never repeat paid execution after interruption.
 
-Never replace this operation with a loop of `create_task` calls. For revisions, ask which confirmed axis value or failed variant to change, preserve approved outputs, and invoke a new fission run only after the user confirms the revised experiment.
+For revisions, ask which axis value or failed variant to change only when the request is ambiguous, preserve accepted outputs, and hand only the revised experiment back to the host.

--- a/skills/video-remake/SKILL.md
+++ b/skills/video-remake/SKILL.md
@@ -7,20 +7,20 @@ description: >
   video with controlled replacements. The source video must remain attached.
 metadata:
   author: renoise
-  version: 0.1.0
+  version: 0.1.1
   category: video-production
   tags: [video, remake, replication, replacement, portable]
 ---
 
 # Reference Video Remake / 复刻视频 / 剪同款
 
-This is a two-gate workflow. The current host owns authorized media analysis, materials, live capabilities, costs, approvals, and tasks. This skill owns slot matching, creative decisions, and resumable plan state kept in the conversation.
+This workflow resolves replacement slots before final generation. The current host owns authorized media analysis, materials, live capabilities, costs, spending approvals, and tasks. This skill owns slot matching, creative decisions, and resumable plan state kept in the conversation.
 
 ## Runtime Boundary
 
 Use only capabilities and references exposed by the current host. Do not invoke local executables, request filesystem paths, or emulate missing analysis/material/task operations. Before selecting a model or writing prompts, read `../model-routing/SKILL.md` and inspect live capabilities.
 
-Use the user's language for analysis, plans, approvals, and results. If retained or replacement content contains dialogue, voiceover, or narration, confirm the spoken language before final prompts and keep every spoken line verbatim in that language.
+Use the user's language for analysis, plans, approvals, and results. If retained or replacement content contains dialogue, voiceover, or narration, use the explicitly requested or safely inferable spoken language; clarify only when ambiguous, and keep every spoken line verbatim in that language.
 
 ## Non-Negotiable Source Policy
 
@@ -85,11 +85,11 @@ Use this priority:
 
 1. User-provided host-authorized material that clearly matches the slot.
 2. Existing owner-scoped Renoise material confirmed by the user.
-3. Generate a replacement image from the slot prompt through the host's approval-controlled generation flow.
+3. Generate a replacement image from the slot prompt through the active host execution workflow.
 
 Never let filename similarity alone choose a character or product. Show the proposed mapping with source, description, and intended role.
 
-### Gate 1 — Plan and Slot Cost
+### Slot Plan and Cost
 
 Present in the user's language:
 
@@ -100,15 +100,14 @@ Present in the user's language:
 - live estimated cost for missing slot images;
 - the fact that the source video will be attached to final generation.
 
-Wait for explicit approval before generating a missing slot.
+If a proposed slot mapping is ambiguous, ask the user to resolve that mapping. Otherwise, hand each requested missing slot and its complete parameters to the active host execution workflow.
 
-For every approved generated slot:
+For every generated slot:
 
-1. Estimate with actual parameters.
-2. Submit through the host approval flow.
-3. Record the returned task ID immediately.
-4. Poll/resume that ID; never repeat create after a wait interruption.
-5. Register the approved result as a reusable material only once.
+1. Follow the host's execution, estimate, and approval policy.
+2. Record any task identifier returned by the host immediately.
+3. Resume that task after a wait interruption; never repeat paid execution blindly.
+4. Register the approved result as a reusable material only once.
 
 For user-provided references, register the authorized item once. Record the returned material ID and full server filename. Prompt mentions must use that complete filename, including extension.
 
@@ -130,7 +129,7 @@ The final prompt must contain no unresolved placeholder.
 
 Request a live estimate with actual duration, resolution, output controls, and full material set; also read the live balance.
 
-### Gate 2 — Final Prompt, Assets, and Video Cost
+### Final Prompt, Assets, and Video Cost
 
 Present in the user's language:
 
@@ -140,11 +139,11 @@ Present in the user's language:
 - generation parameters;
 - final estimated cost and account balance.
 
-Wait for explicit approval before creating the video task.
+Hand these complete arguments to the active host execution workflow; do not assume a particular tool, command, card, or approval interface.
 
 ## Phase 4 — Generate and Resume Safely
 
-Submit through the host's approval-controlled generation capability and record the returned task ID immediately. Poll/resume that same ID after interruption or timeout; never repeat paid create blindly.
+Execute through the active host workflow and record any returned task identifier immediately. Resume that same task after interruption or timeout; never repeat paid execution blindly.
 
 Return the result URL, task ID, source/slot mapping, and warnings. For revisions, keep approved slot materials and change only the identified prompt dimension unless the user asks to replace an asset.
 

--- a/tests/single-source.test.mjs
+++ b/tests/single-source.test.mjs
@@ -63,6 +63,7 @@ test('portable skill files contain no local execution instructions', () => {
     /\$\{(?:CLAUDE_SKILL_DIR|CLAUDE_PLUGIN_ROOT)\}/,
     /command -v|Get-Command|prompt-file|Managed Agent Runtime/,
     /`renoise_[a-z]/,
+    /\bcreate_(?:task|video_fission)\b|spending card|\bRun all\b/i,
   ];
 
   for (const skill of manifest.skills.filter((entry) => entry.runtime === 'portable')) {
@@ -249,16 +250,16 @@ test('director stays a thin router with lazily loaded workflows', () => {
   assert.match(director, /workflows\/narrative\.md/);
   assert.match(director, /storyboard-sheet/);
   assert.match(director, /multiple controlled variants from one supplied source/i);
-  assert.match(narrative, /paid anchor images.*explicit prompt-and-cost approval/is);
+  assert.match(narrative, /paid anchor images.*active host workflow/is);
 });
 
-test('video fission analyzes first and submits one controlled batch', () => {
+test('video fission analyzes first and hands off one portable logical batch', () => {
   const fission = readFileSync('skills/video-fission/SKILL.md', 'utf8');
   const director = readFileSync('skills/director/SKILL.md', 'utf8');
   assert.match(fission, /owner-authorized source video/i);
-  assert.match(fission, /Analyze before asking for a direction/i);
-  assert.match(fission, /Create no task before this confirmation/i);
-  assert.match(fission, /Default to \*\*4 outputs\*\*/);
+  assert.match(fission, /Analyze before resolving the direction/i);
+  assert.match(fission, /initial request already names a usable, safe experimental axis[\s\S]*without restating it for text confirmation/i);
+  assert.match(fission, /Use \*\*4 outputs\*\* when no count is supplied[\s\S]*do not ask merely to confirm that default/i);
   assert.match(fission, /Four is not a hard cap/i);
   assert.match(fission, /one axis by default and never more than two/i);
   assert.match(fission, /distinct, testable hypothesis/i);
@@ -267,25 +268,28 @@ test('video fission analyzes first and submits one controlled batch', () => {
   assert.match(fission, /Do not extract or upload a frame/);
   assert.match(fission, /one generation path/i);
   assert.match(fission, /do not invent another mode/i);
-  assert.match(fission, /call `create_video_fission` once/i);
-  assert.match(fission, /one \*\*Run all\*\* confirmation card/i);
-  assert.match(fission, /estimate for every variant and the total/i);
+  assert.match(fission, /Hand Off One Logical Batch/i);
+  assert.match(fission, /native batch primitive when the host exposes one/i);
+  assert.match(fission, /actual parameters needed for per-variant and total estimation/i);
   assert.match(fission, /submit the source video directly as every task's `reference_video`/i);
-  assert.match(fission, /Never replace this operation with a loop of `create_task` calls/i);
-  assert.match(fission, /confirm the spoken language/i);
+  assert.match(fission, /host's approval, concurrency, idempotency, and task-tracking rules/i);
+  assert.match(fission, /spoken language; clarify it only when ambiguous/i);
+  assert.match(fission, /Do not invent tool names or execution interfaces/i);
   assert.match(director, /explicit video fission or multiple controlled variants/i);
   assert.match(director, /use (?:the )?video-fission/i);
 });
 
-test('reference-video remake is a standalone portable skill with approval gates', () => {
+test('reference-video remake delegates execution details to the active host', () => {
   const director = readFileSync('skills/director/SKILL.md', 'utf8');
   const remake = readFileSync('skills/video-remake/SKILL.md', 'utf8');
   assert.match(director, /剪同款[\s\S]*video-remake/);
   assert.match(remake, /^name: video-remake$/m);
   assert.match(remake, /media-analysis capability/i);
   assert.match(remake, /source video is always attached/i);
-  assert.match(remake, /Gate 1/);
-  assert.match(remake, /Gate 2/);
+  assert.match(remake, /Slot Plan and Cost/);
+  assert.match(remake, /Final Prompt, Assets, and Video Cost/);
+  assert.match(remake, /active host execution workflow/);
+  assert.match(remake, /do not assume a particular tool, command, card, or approval interface/i);
   assert.doesNotMatch(remake, /renoise analyze|prompt-file|remake-plan\.json/);
 });
 


### PR DESCRIPTION
## Summary
- keep portable creative skills independent of host tool, command, card, and approval interfaces
- hand complete generation plans to the active host execution workflow
- keep Renoise CLI approval behavior in the local-only execution skill
- clarify only genuinely blocking creative choices and use safe defaults otherwise

## Verification
- npm test